### PR TITLE
Bug selection pose estimation model

### DIFF
--- a/src/components/pages/Step4.vue
+++ b/src/components/pages/Step4.vue
@@ -364,7 +364,7 @@ export default {
         "Share processed data",
         "Share no data",
       ],
-      pose_model: 'OpenPose (recommended, non-commercial research use only)',
+      pose_model: 'openpose',
       pose_models: [
         {"text": "OpenPose (recommended, non-commercial research use only)", "value": "openpose"},
         {"text": "HRNet", "value": "hrnet"},


### PR DESCRIPTION
@AlbertoCasasOrtiz and @suhlrich

I am not really understanding what is happening, but `pose_model` used to be set to `OpenPose (recommended, non-commercial research use only)`, which is the `text` entry of `pose_models`. If you were selecting OpenPose as pose estimation model, then it would populate the `meta` field like this:

![image](https://user-images.githubusercontent.com/19328993/217683251-ca1abf86-0881-4439-97e5-8d3d7fd8beed.png)

If you were selecting `HRNet`, then it would correctly populate the field like this:

![image](https://user-images.githubusercontent.com/19328993/217683393-f9981547-9e57-4739-be53-8bdc2ba6b7c0.png)

I now adjusted the `pose_model` entry to `openpose`, which is the `value` entry of `pose_models`, and the when you now select OpenPose, it populates the field correctly:

![image](https://user-images.githubusercontent.com/19328993/217683533-b654fd7c-f0c3-41b2-94e6-c0010be3a13d.png)

A bit cryptic to me. It was thus a half bug. Because OpenPose is the default in core, everything was working as expected. Lucky us.