### PR TITLE
Subject refresh when dropdown clicked

### DIFF
--- a/src/components/pages/Step4.vue
+++ b/src/components/pages/Step4.vue
@@ -35,7 +35,7 @@
         </v-card-title>
         <v-card-text>
           <v-select
-              @click="reloadSubjects"
+              @click.stop="reloadSubjects"
               @change="isAllInputsValid"
               class="cursor-pointer"
               required

--- a/src/components/pages/Step4.vue
+++ b/src/components/pages/Step4.vue
@@ -35,6 +35,7 @@
         </v-card-title>
         <v-card-text>
           <v-select
+              @click:append="reloadSubjects"
               @change="isAllInputsValid"
               class="cursor-pointer"
               required
@@ -511,6 +512,9 @@ export default {
       setTimeout(() => {
         this.formErrors[input] = state;
       },0)
+    },
+    reloadSubjects() {
+      this.loadSubjects()
     },
     isAllInputsValid() {
         console.log(this.subject)

--- a/src/components/pages/Step4.vue
+++ b/src/components/pages/Step4.vue
@@ -35,7 +35,7 @@
         </v-card-title>
         <v-card-text>
           <v-select
-              @click:append="reloadSubjects"
+              @click="reloadSubjects"
               @change="isAllInputsValid"
               class="cursor-pointer"
               required
@@ -514,6 +514,7 @@ export default {
       },0)
     },
     reloadSubjects() {
+      console.log('reloading subjects')
       this.loadSubjects()
     },
     isAllInputsValid() {


### PR DESCRIPTION
This seems to solve the problem. Do you see any issues, @olehkorkh-planeks?

It does query `/subjects/` twice if you click in the bar part, instead of on the arrow, but that doesn't seem like too big of an issue.