### PR TITLE
fix de-identified message typo

### DIFF
--- a/src/components/pages/Step4.vue
+++ b/src/components/pages/Step4.vue
@@ -60,7 +60,7 @@
             The information on this page as well as videos of your movement are
             uploaded to a secure cloud server for processing. Please have the
             subject select their data sharing preferences below. Identified
-            videos do no have the face blurred, de-identified videos have faces
+            videos do not have the face blurred, de-identified videos have faces
             blurred, and processed data (e.g., joint angles) is de-identified.
             Please read our privacy terms for details.
           </v-tooltip>


### PR DESCRIPTION
"Identified videos do no have the face blurred" -> "Identified videos do *not* have the face blurred"

<img width="1458" alt="opencap-message-typo" src="https://github.com/stanfordnmbl/opencap-viewer/assets/7455790/da41b5fb-7fcf-46e2-a0b1-7e05d8afa44c">
