### PR TITLE
Fix age / Birth year

### DIFF
--- a/src/components/pages/Step4.vue
+++ b/src/components/pages/Step4.vue
@@ -344,14 +344,14 @@
             :error-messages="formErrors.height"
           ></v-text-field>
           <v-text-field
-            v-model="edited_subject.age"
-            label="Age (y)"
+            v-model="edited_subject.birth_year"
+            label="Birth year (yyyy)"
             type="number"
             hide-spin-buttons
             required
-            :rules="[ageRule]"
-            :error="formErrors.age != null"
-            :error-messages="formErrors.age"
+            :rules="[birthYearRule]"
+            :error="formErrors.birth_year != null"
+            :error-messages="formErrors.birth_year"
           ></v-text-field>
           <v-select
               clearable
@@ -419,14 +419,14 @@ export default {
         name: null,
         weight: null,
         height: null,
-        age: null,
+        birth_year: null,
         data_sharing_agreement: null,
       },
       advancedSettingsDialog: false,
       new_subject_dialog: false,
-      edited_subject: {id: "", name:"", weight:"", height:"", age:"", sex_at_birth:"", gender:"", characteristics:""},
+      edited_subject: {id: "", name:"", weight:"", height:"", birth_year:"", sex_at_birth:"", gender:"", characteristics:""},
       selected: null,
-      empty_subject: {id: "", name:"", weight:"", height:"", age:"", sex_at_birth:"", gender:"", characteristics:""},
+      empty_subject: {id: "", name:"", weight:"", height:"", birth_year:"", sex_at_birth:"", gender:"", characteristics:""},
 
       sessionName: "",
       subject: null,
@@ -434,6 +434,7 @@ export default {
       weight: 70,
       height: 1.8,
       data_sharing_0: false,
+      birth_year: "",
       data_sharing: "",
       sex: "",
       gender: "",
@@ -475,19 +476,22 @@ export default {
       },
       heightRule: (v) => {
         if (!v.trim()) return true;
-        if (!isNaN(parseFloat(v)) && v >= 0 && v <= 3.0) return true;
-        return "It is unlikely that the subject is taller than 3 m, are you using the right units? Height should be in m.";
+        if (!isNaN(parseFloat(v)) && v >= .1 && v <= 3.0) return true;
+        if(!isNaN(parseFloat(v)) && v > 3.0) return "It seems unlikely that the subject's height exceeds 3 m. Please ensure that you are using the correct units. The height should be specified in meters (m).";
+        if(!isNaN(parseFloat(v)) && v < .1) return "It seems unlikely that the subject's height is less than 0.1 m. Please ensure that you are using the correct units. The height should be specified in meters (m).";
       },
       weightRule: (v) => {
         if (!v.trim()) return true;
-        if (!isNaN(parseFloat(v)) && v >= 0 && v <= 200.0) return true;
-        return "It is unlikely that the subject is heavier than 200 kg, are you using the right units? Weight should be in kg.";
+        if (!isNaN(parseFloat(v)) && v >= 1 && v <= 200.0) return true;
+        if(!isNaN(parseFloat(v)) && v > 200.0) return "It seems unlikely that the subject's weight exceeds 200 kg. Please ensure that you are using the correct units. The weight should be specified in kilograms (kg).";
+        if(!isNaN(parseFloat(v)) && v < 1) return "It seems unlikely that the subject's weight is less than 1 kg. Please ensure that you are using the correct units. The weight should be specified in kilograms (kg).";
       },
-      ageRule: (v) => {
-        if (!v.trim()) return true;
-        if (!isNaN(parseFloat(v)) && v >= 1 && v <= 100) return true;
-        if(!isNaN(parseFloat(v)) && v > 100) return "It is unlikely that the age of subject is higher than 100 years. Are you using the right units? Age should be in years.";
-        if(!isNaN(parseFloat(v)) && v < 1) return "It is unlikely that the age of subject is lower than 1 years. Are you using the right units? Age should be in years.";
+      birthYearRule: (v) => {
+        const currentYear = new Date().getFullYear();
+        if (!v) return true;
+        if (!isNaN(parseFloat(v)) && v >= 1900 && v <= currentYear) return true;
+        if(!isNaN(parseFloat(v)) && v > currentYear) return `The subject's birth year cannot be set in the future. Please ensure that you are using the correct units. The birth year should be earlier than the current year ${currentYear} and specified in years (yyyy) format.`;
+        if(!isNaN(parseFloat(v)) && v < 1900) return "It seems unlikely that the subject's birth year predates 1900. Please ensure that you are using the correct units. The birth year should be specified in years (yyyy) format.";
       },
       checkboxRule: (v) => !!v || 'The subject must agree to continue!'
     };
@@ -506,9 +510,9 @@ export default {
     subjectsMapped () {
       return this.subjects.map(s => ({
         id: s.id,
-        display_name: `${s.name} (${s.weight} Kg, ${s.height} m, ${s.age} years)`,
+        display_name: `${s.name} (${s.weight} Kg, ${s.height} m, ${s.birth_year})`,
         name: s.name,
-        age: s.age,
+        birth_year: s.birth_year,
         characteristics: s.characteristics,
         gender: s.gender,
         gender_display: this.genders[s.gender],
@@ -590,7 +594,7 @@ export default {
           name: null,
           weight: null,
           height: null,
-          age: null
+          birth_year: null
       }
       if(this.subject != null && this.subject.id === 'new') {
         this.new_subject_dialog = true
@@ -762,7 +766,7 @@ export default {
           name: null,
           weight: null,
           height: null,
-          age: null
+          birth_year: null
       }
     },
     async submitSubjectForm() {
@@ -771,7 +775,7 @@ export default {
           name: null,
           weight: null,
           height: null,
-          age: null
+          birth_year: null
       }
       console.log(this.edited_subject)
 


### PR DESCRIPTION
Fixes #196 

When we switched from Age to Birth Year, we only made changes on the subject page and not on the step 4 page (I did not realize we had the same code in two places). That means all the subjects created from step 4 after we made the change (https://github.com/stanfordnmbl/opencap-viewer/pull/178) have wrong Age / Birth Year.

I tested on `dev`.