### PR TITLE
Try to fix slow Step5 page

### DIFF
--- a/src/store/auth.js
+++ b/src/store/auth.js
@@ -46,8 +46,8 @@ export default {
               username: localStorage.getItem('auth_user'),
               user_id: localStorage.getItem('auth_user_id'),
           })
-        await dispatch('data/loadExistingSessions', {reroute: false, quantity: 20}, { root: true })
-        await dispatch('data/loadSubjects', null, { root: true })
+        // await dispatch('data/loadExistingSessions', {reroute: false, quantity: 20}, { root: true })
+        // await dispatch('data/loadSubjects', null, { root: true })
       }
     },
     async login ({ state, commit }, { username, password }) {


### PR DESCRIPTION
I found that we loads the list of valid sessions every time we validates the token in `auth.js`. I commented these lines. It seems workable but testing is required.