### PR TITLE
Profile pages

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -19,24 +19,6 @@
 
       <QRCodeDialog/>
 
-      <v-btn
-        v-if="!verified"
-        href="https://github.com/stanfordnmbl/opencap-core"
-        target="_blank"
-        text>
-        <span class="mr-2">Find on GitHub</span>
-        <v-icon>mdi-open-in-new</v-icon>
-      </v-btn>
-
-      <v-btn
-        v-if="loggedIn && !verified"
-        @click="logout"
-        text>
-        <span class="mr-2">LOGOUT</span>
-        <v-icon>mdi-logout</v-icon>
-      </v-btn>
-
-
     <profile-dropdown v-if="verified"></profile-dropdown>
 
     </v-app-bar>

--- a/src/App.vue
+++ b/src/App.vue
@@ -19,7 +19,7 @@
 
       <QRCodeDialog/>
 
-    <profile-dropdown v-if="verified"></profile-dropdown>
+    <profile-dropdown v-if="verified" class="ml-8"></profile-dropdown>
 
     </v-app-bar>
 

--- a/src/components/pages/ProfilePage.vue
+++ b/src/components/pages/ProfilePage.vue
@@ -405,7 +405,7 @@ export default {
             country: this.country,
             institution: this.institution,
             profession: this.profession,
-            reason: this.reason,
+            reason: this.reason_of_use,
             website: this.website,
             newsletter: this.newsletter,
           });

--- a/src/components/pages/Verify.vue
+++ b/src/components/pages/Verify.vue
@@ -36,6 +36,10 @@
           @click="onLogin()">Verify</v-btn>            
       </ValidationObserver>
 
+      <router-link class="text-center mt-6" @click.native="handleGoBack" :to="{ name: 'Login' }">
+        Back to Login
+      </router-link>
+
       <!--router-link
         class="mt-4 text-center"
         :to="{ name: 'Register' }">Don't have an account yet? Sign Up</router-link-->
@@ -71,7 +75,7 @@ export default {
       }
     },
     methods: {
-    ...mapActions('auth', ['verify', 'set_skip_forcing_otp']),
+    ...mapActions('auth', ['verify', 'set_skip_forcing_otp', 'logout']),
     ...mapActions('data', ['loadExistingSessions']),
     async onLogin () {
       this.loading = true
@@ -107,6 +111,9 @@ export default {
       }
 
       this.loading = false
+    },
+    async handleGoBack() {
+      this.logout();
     }
   }
 }


### PR DESCRIPTION
- [x] Reason of use (frontend) does not seem to be linked to Reason (backend), see screenshots. -> **Linked.**
- [x] Should we remove Find on Github from the login page? It disappears afterwards so I would not keep it in. -> **Removed.**
- [x] Should we remove Find on Github AND Logout from 2fa page? Same logic + your are not logged in at that time so you should not be able to log out. -> **Removed. Added "Back to Login" to verify to be consistent with rest of app.**
- [x] Can we add space between Reconnect phone and profile image, they are very close to each other -> **Space added.**