### PR TITLE
Sort scalar plots by key

### DIFF
--- a/src/components/ui/ScalarPlot.vue
+++ b/src/components/ui/ScalarPlot.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="scalar-wrapper">
-    <div v-for="(row, row_name, row_idx) in result.metrics" :key="row_idx"
+    <div v-for="(row, row_idx) in sortedMetrics"
+         :key="row_idx"
          :class="row.classes">
       <h2 class="h5 plot-caption">
         {{ row.label }}
@@ -36,6 +37,11 @@
 export default {
   props: ["trialID", 'timePosition', 'result', 'block'],
   name: "scalar-plot",
+  computed: {
+    sortedMetrics() {
+      return Object.keys(this.result.metrics).sort().map((x) => this.result.metrics[x]);
+    }
+  },
   methods: {
     buildBarStyles(row, bar_name) {
       let bar_color = 'grey';


### PR DESCRIPTION
Render the list of scalar plots in alphabetical order of the keys.

Example:

```json
...
  "metrics": {
    "00_walking_speed": {
      "label": "Walking speed (km/h)",
      "value": 1.23,
      "min_limit": 1.0,
      "max_limit": 2.0,
      "colors": ["red", "yellow", "green"],
      "info": "The walking speed is the average speed of the gait cycle.\nIt is calculated as the distance covered in a certain time.\nThe normal walking speed is 1.4 m/s (5 km/h)."
    },
    "01_value_2": {
      "label": "Double support time (% gait cycle)",
      "value": 25.68,
      "min_limit": 35,
      "max_limit": 38.5,
      "colors": ["green", "yellow", "red"]
    },
    "02_value_3": {
      "label": "Step width (m)",
      "value": 4,
      "min_limit": 0.14,
      "max_limit": 0.15,
      "colors": ["green", "yellow", "red"]
    },
  ...
...
```