### PR TITLE
Menu disappears when dialog appears. Fixed bug in rename session.

### DIFF
--- a/src/components/pages/SelectSession.vue
+++ b/src/components/pages/SelectSession.vue
@@ -83,7 +83,10 @@
                         v-click-outside="clickOutsideDialogSessionHideMenu"
                         max-width="500">
                   <template v-slot:activator="{ on }">
-                    <v-list-item link v-on="on">
+                    <v-list-item link v-on="{
+                          ...on,
+                          click: (e) => { on.click(e); item.isMenuOpen = false; rename_dialog = true; }
+                        }">
                       <v-list-item-title>Rename</v-list-item-title>
                     </v-list-item>
                   </template>
@@ -111,7 +114,7 @@
 
                             <v-spacer></v-spacer>
 
-                            <v-btn class="text-right" :disabled="invalid" @click="item.isMenuOpen = false; remove_dialog = false; renameSession(item, sessionNewName);">
+                            <v-btn class="text-right" :disabled="invalid" @click="item.isMenuOpen = false; rename_dialog = false; renameSession(item, sessionNewName);">
                                 Rename Session
                             </v-btn>
                           </ValidationObserver>
@@ -128,7 +131,10 @@
                         v-click-outside="clickOutsideDialogSessionHideMenu"
                         max-width="500">
                   <template v-slot:activator="{ on }">
-                    <v-list-item link v-if="!item.trashed" v-on="on">
+                    <v-list-item link v-if="!item.trashed" v-on="{
+                          ...on,
+                          click: (e) => { on.click(e); item.isMenuOpen = false; remove_dialog = true; }
+                        }">
                       <v-list-item-title>Trash</v-list-item-title>
                     </v-list-item>
                   </template>
@@ -173,7 +179,10 @@
                         v-click-outside="clickOutsideDialogSessionHideMenu"
                         max-width="500">
                   <template v-slot:activator="{ on }">
-                    <v-list-item link v-if="item.trashed" v-on="on">
+                    <v-list-item link v-if="item.trashed" v-on="{
+                          ...on,
+                          click: (e) => { on.click(e); item.isMenuOpen = false; restore_dialog = true; }
+                        }">
                       <v-list-item-title v-on="on">Restore</v-list-item-title>
                     </v-list-item>
                   </template>

--- a/src/components/pages/Step5.vue
+++ b/src/components/pages/Step5.vue
@@ -55,7 +55,10 @@
                                     v-click-outside="clickOutsideDialogTrialHideMenu"
                                     max-width="500">
                               <template v-slot:activator="{ on }">
-                                <v-list-item link v-if="!t.trashed" v-on="on">
+                                <v-list-item link v-if="!t.trashed" v-on="{
+                                  ...on,
+                                  click: (e) => { on.click(e); t.isMenuOpen = false; remove_dialog = true; }
+                                }">
                                   <v-list-item-title>Trash</v-list-item-title>
                                 </v-list-item>
                               </template>
@@ -99,7 +102,10 @@
                                     v-click-outside="clickOutsideDialogTrialHideMenu"
                                     max-width="500">
                               <template v-slot:activator="{ on }">
-                                <v-list-item link v-if="t.trashed" v-on="on">
+                                <v-list-item link v-if="t.trashed" v-on="{
+                                    ...on,
+                                    click: (e) => { on.click(e); t.isMenuOpen = false; restore_dialog = true; }
+                                  }">
                                   <v-list-item-title>Restore</v-list-item-title>
                                 </v-list-item>
                               </template>
@@ -141,7 +147,10 @@
                                     v-click-outside="clickOutsideDialogTrialHideMenu"
                                     max-width="500">
                               <template v-slot:activator="{ on }">
-                                <v-list-item link v-if="!t.trashed" v-on="on">
+                                <v-list-item link v-if="!t.trashed" v-on="{
+                                    ...on,
+                                    click: (e) => { on.click(e); t.isMenuOpen = false; permanent_delete_dialog = true; }
+                                  }">
                                   <v-list-item-title >Delete</v-list-item-title>
                                 </v-list-item>
                               </template>


### PR DESCRIPTION
Now when clicking on trash or delete, the dialog appears and the menu disappears as with the rest of the buttons.

The same was happening on sessions, so I fixed it there to.

Additionally, when applying rename in sessions, the dialog was not disappearing. This is fixed now too.