### PR TITLE
"Go to visualizer" button on Analysis Dashboard page

### DIFF
--- a/src/components/pages/AnalysisDashboard.vue
+++ b/src/components/pages/AnalysisDashboard.vue
@@ -112,6 +112,10 @@
                 <v-btn class="w-100 mt-4" :to="{ name: 'SelectSession' }">Back to session list
                 </v-btn>
 
+                <v-btn class="w-100 mt-4" @click="$router.push({ name: 'Session', params: { id: session_selected.id } })">
+                  Go to Visualizer
+                </v-btn>
+
               </div>
             </div>
 


### PR DESCRIPTION
This PR adds a button to the Analysis Dashboard page to go back to the visualizer. (#407) Tested locally and it seems like it is working fine.