### PR TITLE
Support for checkerboard lying on the floor

### DIFF
--- a/src/components/pages/Calibration.vue
+++ b/src/components/pages/Calibration.vue
@@ -21,9 +21,13 @@
 
       <v-card-text class="d-flex align-center">
         <ul class="flex-grow-1">
-          <li>It should be visible by all cameras (nothing in the way of cameras' view when hitting Calibrate)</li>
-          <li>It should be horizontal (longer side on the floor)</li>
-          <li>It should be perpendicular to the floor (not lying on the floor)</li>         
+          <li>It should be visible by all cameras (nothing in the way of cameras' view when hitting Calibrate)</li>          
+          <li>It can be either perpendicular to the floor (default) or lying on the floor (beta feature; select Lying placement below)</li>
+          <li>If perpendicular to the floor, then:
+            <ul>
+              <li>Place it horizontally (longer side on the floor)</li>
+            </ul>
+          </li>
         </ul>
 
         <div class="image-container pa-3">
@@ -51,7 +55,38 @@
 
           <v-text-field
             v-model="squareSize"
-            label="Square size (mm)"/>
+            label="Square size (mm)"
+            class="mr-3"/>
+
+          <v-select
+            v-model="placement"
+            :items="['Perpendicular', 'Lying']"
+            label="Placement on the floor"
+            class="mr-0"/>
+
+          <v-tooltip bottom="" max-width="500px">
+            <template v-slot:activator="{ on }">
+              <v-icon v-on="on" class="ml-0">mdi-help-circle-outline</v-icon>
+            </template>
+            <div>
+              The origin of the world frame is the top-left black-to-black corner of the board (red dot with a blue outline in the picture on the right).
+              <br><br>
+              When positioned perpendicular to the floor, transformations are applied so that in the processed data:
+              <ul>
+                <li>The forward axis of the world frame is perpendicular to the board (coming out).</li>
+                <li>The vertical axis of the world frame is parallel to the board (going up).</li>
+              </ul>
+              <br>
+              When positioned lying on the floor, transformations are applied so that in the processed data:
+              <ul>
+                <li>The forward axis of the world frame is parallel to the board (along the shorter side).</li>
+                <li>The vertical axis of the world frame is perpendicular to the board (going up).</li>
+              </ul>
+              <br>
+              To align movement with the forward axis of the world frame when the board is lying on the floor, place the board such that its forward axis is parallel to the direction of movement. 
+              For example, for walking, place the board with the longer side perpendicular to the walking direction. Note that this alignment is optional, as the system can operate with the board in any orientation.
+            </div>
+          </v-tooltip>
         </div>
 
         <div class="image-container pa-3">
@@ -79,6 +114,7 @@ export default {
       rows: 4,
       cols: 5,
       squareSize: 35,
+      placement: 'Perpendicular',
       busy: false,
       imgs: null,
       lastPolledStatus: "",
@@ -108,7 +144,8 @@ export default {
         this.setCalibration({
           rows: this.rows,
           cols: this.cols,
-          squareSize: this.squareSize
+          squareSize: this.squareSize,
+          placement: this.placement
         })
         try {
           const resUpdate = await axios.get(`/sessions/${this.session.id}/set_metadata/`, {
@@ -116,7 +153,7 @@ export default {
               cb_rows: this.rows,
               cb_cols: this.cols,
               cb_square: this.squareSize,
-              cb_placement: "backWall"
+              cb_placement: this.placement
               }
             })
 

--- a/src/components/pages/Session.vue
+++ b/src/components/pages/Session.vue
@@ -693,6 +693,7 @@
             rows: state => state.data.rows,
             cols: state => state.data.cols,
             squareSize: state => state.data.squareSize,
+            placement: state => state.data.placement,
   
             // step Neutral data
             identifier: state => state.data.identifier,

--- a/src/store/data.js
+++ b/src/store/data.js
@@ -31,6 +31,7 @@ export default {
     rows: 4,
     cols: 5,
     squareSize: 35,
+    placement: 'Perpendicular',
     // step 3
     trialId: '',
 
@@ -220,10 +221,11 @@ export default {
     setConnectDevices (state, { cameras }) {
       state.cameras = cameras
     },
-    setCalibration (state, { rows, cols, squareSize }) {
+    setCalibration (state, { rows, cols, squareSize, placement }) {
       state.rows = rows
       state.cols = cols
       state.squareSize = squareSize
+      state.placement = placement
     },
     setTrialId (state, trialId) {
       state.trialId = trialId


### PR DESCRIPTION
@suhlrich @carmichaelong @AlbertoCasasOrtiz 

This PR is coupled with https://github.com/stanfordnmbl/opencap-core/pull/220, it adds support for having the checkerboard lying on the floor.

The visual changes are slight updates to the calibration screen: text in the first part, drop down menu in the second part + ? icon with some more info (see below).

1. Could you please review the text, I tried to make things clear without overwhelming the user.
2. I replaced `backWall` by `Perpendicular`. I find it clearer. We can keep `backWall` and map it somehow to `Perpendicular`. Whatever is fine with me. In core, `backWall` is only used once to set the rotation angles, so I made a change [there](https://github.com/stanfordnmbl/opencap-core/blob/flat_checkerboard/main.py#L309).
3. I tested (Model Health codebase) and it looks fine (see screenshot below)
4. I tried to have the (?) closer to the drop down menu, but I gave up after 10-min :) @AlbertoCasasOrtiz or @carmichaelong it should take you 1 min ;)

Note: When the checkerboard is perpendicular to the floor, it could be good to detect if the shorter or longer side is on the floor and support both cases.

![image](https://github.com/user-attachments/assets/3b8119cf-65dc-4774-a8e3-7265072c0d6d)
![image](https://github.com/user-attachments/assets/1518173f-e333-47f4-be95-a0a80a1c6475)

