### PR TITLE
Ipad - Fixed the neutral page

### DIFF
--- a/src/components/pages/ConnectDevices.vue
+++ b/src/components/pages/ConnectDevices.vue
@@ -94,7 +94,7 @@ export default {
       username: state => state.auth.username,
     }),
     hasMonoAccess() {
-      const allowedUsers = ['selimgilon', 'suhlrich', 'antoine'];
+      const allowedUsers = ['selimgilon', 'suhlrich', 'antoine', 'dev_user'];
       const currentUser = this.username || localStorage.getItem('auth_user');
       return allowedUsers.includes(currentUser);
     },
@@ -118,7 +118,7 @@ export default {
       this.setConnectDevices({
         cameras: this.cameras
       })
-      this.$router.push(`/${this.session.id}/neutral`);
+      this.$router.push({ path: `/${this.session.id}/neutral`, query: { isMono: 'true' } });
     }
   }
 }

--- a/src/components/pages/Neutral.vue
+++ b/src/components/pages/Neutral.vue
@@ -1,373 +1,363 @@
 <template>
   <MainLayout
-    leftButton="Back"
     :step="4"
+    :fixedHeight="false"
     :rightDisabled="busy || disabledNextButton"
     @left="$router.push(`/${session.id}/calibration`)">
 
-    <template v-slot:right>
-      <v-btn
-        v-if="hasMonoAccess"
-        class="mr-2"
-        color="warning"
-        :disabled="busy || disabledNextButton"
-        @click="skipProcessing">
-        Next to monocular
-      </v-btn>
-      <v-btn
-        :disabled="busy || disabledNextButton"
-        :loading="busy && !imgs"
-        @click="onNext">
-        {{ rightButtonCaption }}
-      </v-btn>
-    </template>
+    <!-- Ensure MainLayout's own slots are effectively empty or hidden -->
+    <template v-slot:left><div class="d-none"></div></template>
+    <template v-slot:right><div class="d-none"></div></template>
 
-    <v-card v-if="imgs" class="step-4-1 pa-2 d-flex flex-column">
-      <v-card-title class="justify-center"> Verify neutral pose </v-card-title>
+    <div class="neutral-wrapper">
+      <div class="neutral-content">
+        <v-card v-if="imgs" class="step-4-1 pa-2 d-flex flex-column">
+          <v-card-title class="justify-center"> Verify neutral pose </v-card-title>
 
-      <v-card-text class="d-flex flex-grow-1 scroll-y">
-        <div
-          v-for="(imgCol, colIndex) in imgCols"
-          :key="colIndex"
-          class="d-flex flex-column"
-        >
-          <img
-            v-for="(img, imgIndex) in imgCol"
-            :key="imgIndex"
-            :src="img"
-            width="150"
-            class="ma-1"
-          />
-        </div>
-      </v-card-text>
-    </v-card>
-
-    <div v-else class="step-4-1 d-flex flex-column">
-
-      <v-card class="mb-4">
-        <v-card-title class="justify-center subject-title">
-          Session Info
-        </v-card-title>
-          <v-card-text>
-            <v-row align="center">
-              <v-col cols="11">
-                <v-autocomplete
-                  ref="selectSubjectsRef"
-                  required
-                  v-model="subject"
-                  item-text="display_name"
-                  item-value="id"
-                  label="Subject"
-                  :items="loaded_subjects"
-                  :loading="subject_loading"
-                  :search-input.sync="subject_search"
-                  return-object
-                >
-                  <template v-slot:append-item>
-                    <div v-intersect="loadNextSubjectsListPage" />
-                  </template>
-                  <template v-slot:selection>{{ subject.display_name }}</template>
-                </v-autocomplete>
-
-<!--                <v-select-->
-<!--                    ref="selectSubjectsRef"-->
-<!--                    @click="reloadSubjects"-->
-<!--                    @input="isAllInputsValidSelectSubject"-->
-<!--                    class="cursor-pointer"-->
-<!--                    required-->
-<!--                    v-model="subject"-->
-<!--                    item-text="display_name"-->
-<!--                    item-value="id"-->
-<!--                    label="Subject"-->
-<!--                    :items="subjectSelectorChoices"-->
-<!--                    return-object-->
-<!--                ></v-select>-->
-              </v-col>
-              <v-col cols="1">
-                <v-btn
-                  icon
-                  @click="openNewSubjectPopup">
-                  <v-icon>mdi-plus</v-icon>
-                </v-btn>
-              </v-col>
-            </v-row>
-            <v-text-field
-              v-model="sessionName"
-              label="Session Name (optional)"
-              type="text"
-              required
-              :error="formErrors.name != null"
-              :error-messages="formErrors.name"
-            ></v-text-field>
-<!--            <div>-->
-<!--              <ul>-->
-<!--                <li>loaded_subjects: {{ loaded_subjects }}</li>-->
-<!--                <li>subject: {{ subject }}</li>-->
-<!--                <li>subject_loading: {{ subject_loading }}</li>-->
-<!--                <li>subject_search: {{ subject_search }}</li>-->
-
-<!--                <li>sessionName: {{ sessionName }}</li>-->
-<!--              </ul>-->
-
-<!--            </div>-->
-          </v-card-text>
-      </v-card>
-
-      <v-card class="mb-4">
-        <div class="d-flex justify-center">
-          <v-card-title class="justify-center data-title">
-            Data sharing agreement
-          </v-card-title>
-          <v-tooltip bottom="">
-            <template v-slot:activator="{ on }">
-              <v-icon v-on="on"> mdi-help-circle-outline </v-icon>
-            </template>
-            The information on this page as well as videos of your movement are
-            uploaded to a secure cloud server for processing. Please have the
-            subject select their data sharing preferences below. Identified
-            videos do not have the face blurred, de-identified videos have faces
-            blurred, and processed data (e.g., joint angles) is de-identified.
-            Please read our privacy terms for details.
-          </v-tooltip>
-        </div>
-
-        <v-card-text class="d-flex flex-column align-center checkbox-wrapper">
-          <ValidationObserver
-            tag="div"
-            class="d-flex flex-column checkbox-box"
-            ref="observer"
-          >
-            <v-checkbox
-              v-model="data_sharing_0"
-              @click="isAllInputsValid"
-              label="The subject understands that the recorded identified videos and processed data are stored in secure PHI-compliant storage and agrees to share them with the OpenCap development team for algorithm development. We may use this data in scientific publications, but will only publicly share the data that the subject agrees to share below."
-              :rules="[checkboxRule]"
-              required=""
-            ></v-checkbox>
-
-            <ValidationProvider
-              rules="required"
-              v-slot="{ errors }"
-              name="Data sharing agreement"
+          <v-card-text class="d-flex flex-grow-1 scroll-y">
+            <div
+              v-for="(imgCol, colIndex) in imgCols"
+              :key="colIndex"
+              class="d-flex flex-column"
             >
-              <v-select
-                v-model="data_sharing"
-                label="Please select which data the subject is willing to share publicly; we encourage the subject to share as much as they feel comfortable."
-                @change="isAllInputsValid"
-                :items="data_sharing_choices"
-                :error="errors.length > 0"
-                :error-messages="errors[0]"
+              <img
+                v-for="(img, imgIndex) in imgCol"
+                :key="imgIndex"
+                :src="img"
+                width="150"
+                class="ma-1"
               />
-            </ValidationProvider>
-          </ValidationObserver>
-        </v-card-text>
-      </v-card>
- 
-    <div class="d-flex justify-center">
-        <template>
-        <div class="text-center">
-          <v-btn
-            color="primary-dark"
-            class="mt-4 mb-4 ml-4 mr-4"
-            x-large
-            @click="openAdvancedSettings"
-          >
-            Advanced Settings
-          </v-btn>
+            </div>
+          </v-card-text>
+        </v-card>
 
-          <v-dialog
-            v-model="advancedSettingsDialog"
-            scrollable
-            width="700px"
-            max-height="400px"
-          >
-            <v-card height="fit-content">
-              <v-card-actions class="justify-end">
-                <v-btn color="primary-dark" @click="advancedSettingsDialog = false">✖</v-btn>
-              </v-card-actions>
+        <div v-else class="neutral-layout">
+          <div class="left-column" :class="{ 'full-width': isMonocularMode }">
+            <v-card class="mb-4">
+              <v-card-title class="justify-center subject-title">
+                Session Info
+              </v-card-title>
+                <v-card-text>
+                  <v-row align="center">
+                    <v-col cols="11">
+                      <v-autocomplete
+                        ref="selectSubjectsRef"
+                        required
+                        v-model="subject"
+                        item-text="display_name"
+                        item-value="id"
+                        label="Subject"
+                        :items="loaded_subjects"
+                        :loading="subject_loading"
+                        :search-input.sync="subject_search"
+                        return-object
+                      >
+                        <template v-slot:append-item>
+                          <div v-intersect="loadNextSubjectsListPage" />
+                        </template>
+                        <template v-slot:selection>{{ subject.display_name }}</template>
+                      </v-autocomplete>
+                    </v-col>
+                    <v-col cols="1">
+                      <v-btn
+                        icon
+                        @click="openNewSubjectPopup">
+                        <v-icon>mdi-plus</v-icon>
+                      </v-btn>
+                    </v-col>
+                  </v-row>
+                  <v-text-field
+                    v-model="sessionName"
+                    label="Session Name (optional)"
+                    type="text"
+                    required
+                    :error="formErrors.name != null"
+                    :error-messages="formErrors.name"
+                  ></v-text-field>
+                </v-card-text>
+            </v-card>
 
-              <v-card-title class="justify-center data-title">
-                <span class="mr-2">Scaling setup</span>
-                <v-tooltip bottom="" max-width="500px">
+            <v-card class="mb-4">
+              <div class="d-flex justify-center">
+                <v-card-title class="justify-center data-title">
+                  Data sharing agreement
+                </v-card-title>
+                <v-tooltip bottom="">
                   <template v-slot:activator="{ on }">
                     <v-icon v-on="on"> mdi-help-circle-outline </v-icon>
                   </template>
-                  OpenCap uses data from the neutral pose to scale the musculoskeletal model to the anthropometry of the subject.
-                  By default, OpenCap assumes that the subject is standing with an upright posture and the feet pointing forward (i.e., straight back and no bending or rotation at the hips, knees, or ankles) as shown in the example neutral pose. These assumptions are modeled in the OpenSim scaling setup.
-                  If the subject cannot adopt this pose, you can select the "Any pose" scaling setup, which does not assume any specific posture but still requires all body segments to be visible by at least two cameras.
-                  We recommend using the default scaling setup unless the subject cannot adopt the upright standing neutral pose.
+                  The information on this page as well as videos of your movement are
+                  uploaded to a secure cloud server for processing. Please have the
+                  subject select their data sharing preferences below. Identified
+                  videos do not have the face blurred, de-identified videos have faces
+                  blurred, and processed data (e.g., joint angles) is de-identified.
+                  Please read our privacy terms for details.
                 </v-tooltip>
-              </v-card-title>
-              <v-card-text class="d-flex flex-column align-center checkbox-wrapper">
-                <v-select
-                    v-model="scaling_setup"
-                    label="Select scaling setup"
-                    v-bind:items="scaling_setups"
-                  />
-              </v-card-text>
+              </div>
 
-              <v-card-title class="justify-center data-title">
-                <span class="mr-2">Human pose estimation model</span>
-                <v-tooltip bottom="" max-width="500px">
-                  <template v-slot:activator="{ on }">
-                    <v-icon v-on="on"> mdi-help-circle-outline </v-icon>
-                  </template>
-                  OpenCap supports two human pose estimation models: OpenPose and HRNet. We recommend using OpenPose for computation speed, but both models provide similar accuracy.
-                  OpenPose is restricted to academic or non-profit organization non-commercial research use (consult the license at https://github.com/CMU-Perceptual-Computing-Lab/openpose/blob/master/LICENSE).
-                  HRNet, as implemented by Open-MMLab, has a permissive Apache 2.0 license (consult the license at https://github.com/open-mmlab/mmpose/blob/master/LICENSE).
-                  Please ensure that you have the rights to use the model you select. The OpenCap authors deny any responsibility regarding license infringement.
-                </v-tooltip>
-              </v-card-title>
               <v-card-text class="d-flex flex-column align-center checkbox-wrapper">
-                <v-select
-                    v-model="pose_model"
-                    label="Select human pose estimation model"
-                    v-bind:items="pose_models"
-                  />
-              </v-card-text>
-  
-              <v-card-title class="justify-center data-title">
-                Framerate
-              </v-card-title>
-              <v-card-text class="d-flex flex-column align-center checkbox-wrapper">
-                <v-select
-                    v-model="framerate"
-                    label="Select framerate"
-                    v-bind:items="framerates_available"
-                    @change="updateFrequency"
-                  />
-              </v-card-text>
+                <ValidationObserver
+                  tag="div"
+                  class="d-flex flex-column checkbox-box"
+                  ref="observer"
+                >
+                  <v-checkbox
+                    v-model="data_sharing_0"
+                    @click="isAllInputsValid"
+                    label="The subject understands that the recorded identified videos and processed data are stored in secure PHI-compliant storage and agrees to share them with the OpenCap development team for algorithm development. We may use this data in scientific publications, but will only publicly share the data that the subject agrees to share below."
+                    :rules="[checkboxRule]"
+                    required=""
+                  ></v-checkbox>
 
-              <v-card-title class="justify-center data-title">
-                <span class="mr-2">Musculoskeletal model</span>
-                <v-tooltip bottom="" max-width="500px">
-                  <template v-slot:activator="{ on }">
-                    <v-icon v-on="on"> mdi-help-circle-outline </v-icon>
-                  </template>
-                  Full body model: Musculoskeletal model with 33 degrees of freedom from Lai et al. 2017 (https://pubmed.ncbi.nlm.nih.gov/28900782/) with modified hip abductor muscle paths from Uhlrich et al. 2022 (https://pubmed.ncbi.nlm.nih.gov/35798755/). Recommended for primarily lower extremity tasks (e.g., gait).
-                  <br><br>
-                  Full body model with ISB shoulder: Incorporates a 6 degree-of-freedom shoulder complex joint. It incorporates a scapulothoracic body with 3 translational degrees of freedom relative to the torso. The glenohumoral joint uses the Y-X-Y rotation sequence (elevation plane, elevation, rotation) recommended by the ISB (https://pubmed.ncbi.nlm.nih.gov/15844264/). Recommended for upper extremity tasks (e.g., pitching).
-                </v-tooltip>
-              </v-card-title>
-              <v-card-text class="d-flex flex-column align-center checkbox-wrapper">
-                <v-select
-                    v-model="openSimModel"
-                    label="Select musculoskeletal model"
-                    v-bind:items="openSimModels"
-                  />
-              </v-card-text>
-
-              <v-card-title class="justify-center data-title">
-                <span class="mr-2">Marker augmenter model</span>
-                <v-tooltip bottom="" max-width="500px">
-                  <template v-slot:activator="{ on }">
-                    <v-icon v-on="on"> mdi-help-circle-outline </v-icon>
-                  </template>
-                  OpenCap uses an LSTM model, also called marker augmenter model, to predict the 3D position of 43 anatomical markers from the 3D position of 20 video keypoints (https://www.biorxiv.org/content/10.1101/2022.07.07.499061v1). 
-                  The anatomical markers are used as input to OpenSim to compute joint angles using inverse kinematics.
-                  <br><br>
-                  The latest model (v0.3, default) is more accurate and more robust to different activities than v0.2. We recommend using it for new studies. 
-                  It was trained on 1475 hours of motion capture data and resulted in an RMSE of 4.4 +/- 0.3 deg (OpenPose) and 4.1 +/- 0.3 deg (HRnet) for joint angles across 18 degrees of freedom.
-                  <br><br>                  
-                  The original model (v0.2) underwent training using 708 hours of motion capture data, yielding an RMSE of 4.8 +/- 0.2 deg (OpenPose and HRNet) for joint angles across 18 degrees of freedom. 
-                  <br><br>
-                  The performance evaluation was conducted in comparison to marker-based motion capture using data from 10 subjects performing 4 different types of activities (walking, squatting, sit-to-stand, and drop jumps). 
-                  The dataset used for training the latest model (v0.3) contains data from more subjects and from a more diverse set of tasks; model v0.3 is therefore expected to be more accurate for a wider variety of tasks and to yield more accurate results.
-                  We recommend using v0.3 for new studies but warn users that we might still adjust the model in the future. 
-                  If you would like to use the model that was default prior to 07-30-2023, select v0.2.
-                </v-tooltip>
-              </v-card-title>
-              <v-card-text class="d-flex flex-column align-center checkbox-wrapper">
-                <v-select
-                    v-model="augmenter_model"
-                    label="Select marker augmenter model"
-                    v-bind:items="augmenter_models"
-                  />
-              </v-card-text>
-
-              <v-card-title class="justify-center data-title">
-                <span class="mr-2">Filter frequency</span>
-                <v-tooltip bottom="" max-width="500px">
-                  <template v-slot:activator="{ on }">
-                    <v-icon v-on="on"> mdi-help-circle-outline </v-icon>
-                  </template>
-                  OpenCap uses a low-pass Butterworth filter to smooth the 2D video keypoints. The filter frequency is the cutoff frequency of the filter.
-                  <br><br>                  
-                  By default, OpenCap uses a filter frequency of half the framerate (if the framerate is 60fps, the filter frequency is 30Hz), except for gait activities, for which the filter frequency is 12Hz.
-                  <br><br>
-                  You can here enter a different filter frequency. WARNING: this filter frequency will be applied to ALL motion trials of your session. As per the Nyquist Theorem, the filter frequency should be less than half the framerate.
-                  If you enter a filter frequency higher than half the framerate, we will use half the framerate as the filter frequency instead.
-                  <br><br>
-                  We recommend consulting the literature to find a suitable filter frequency for your specific tasks. If you are unsure, we recommend using the default filter frequency.
-                </v-tooltip>
-              </v-card-title>
-              <v-card-text class="d-flex flex-column align-center checkbox-wrapper">
-                <v-combobox
-                :key="componentKey"
-                v-model="tempFilterFrequency"
-                label="Enter frequency (Hz) or choose default"
-                :items="filter_frequencies"
-                :allow-custom="true"
-                :return-object="false"
-                @change="validateAndSetFrequency"
-                item-text="text"
-                item-value="value"
-                ></v-combobox>
+                  <ValidationProvider
+                    rules="required"
+                    v-slot="{ errors }"
+                    name="Data sharing agreement"
+                  >
+                    <v-select
+                      v-model="data_sharing"
+                      label="Please select which data the subject is willing to share publicly; we encourage the subject to share as much as they feel comfortable."
+                      @change="isAllInputsValid"
+                      :items="data_sharing_choices"
+                      :error="errors.length > 0"
+                      :error-messages="errors[0]"
+                    />
+                  </ValidationProvider>
+                </ValidationObserver>
               </v-card-text>
             </v-card>
-          </v-dialog>
-        </div>
-      </template>
-    </div>
-    </div>
-
-    <v-card class="step-4-2 ml-4 d-flex images-box">
-
-      <v-card class="mb-0">
-        <v-card-text style="padding-top: 5px; padding-bottom: 0; font-size: 16px;">
-        <p>{{ n_videos_uploaded }} of {{ n_calibrated_cameras }} videos uploaded</p>
-        </v-card-text>
-      </v-card>
-
-      <v-card-title class="justify-center">
-        Record neutral pose
-      </v-card-title>
       
-      <v-card-text class="d-flex justify-center align-center">
-        <div class="d-flex flex-column mr-4">
-          <ul>
-            <li>
-              The subject should adopt the example neutral pose
-              <ul>
-                <li class="space-above-small">Upright standing posture with feet pointing forward</li>
-                <li class="space-above-small">Straight back and no bending or rotation at the hips, knees, or ankles</li>
-              </ul>
-            </li>
-            <li class="space-above-small">The subject should stand still</li>
-            <li class="space-above-small">
-              The subject should be visible by all cameras 
-              <ul>
-                <li class="space-above-small">Nothing in the way
-                  of cameras view when hitting Record</li>
-              </ul>
-            </li>
-          </ul>
-        </div>
-        <div class="d-flex flex-column align-center ">
-          <span class="sub-header" style="font-size: 18px;">Example neutral pose</span>
-          <ExampleImage
-            image="/images/step-4/big_good_triangle.jpg"
-            :width="256"
-            :height="341"
-            good
-          />
-        </div>
-      </v-card-text>
-      <v-card-title class="justify-center" style="font-size: 18px; word-break: keep-all;">
-        If the subject cannot adopt the example neutral pose, select "Any pose" scaling setup under Advanced Settings
-      </v-card-title>
+            <div class="d-flex justify-center">
+              <template>
+                <div class="text-center">
+                  <v-btn
+                    color="primary-dark"
+                    class="mt-4 mb-4 ml-4 mr-4"
+                    x-large
+                    @click="openAdvancedSettings"
+                  >
+                    Advanced Settings
+                  </v-btn>
 
-    </v-card>
+                  <v-dialog
+                    v-model="advancedSettingsDialog"
+                    scrollable
+                    width="700px"
+                    max-height="400px"
+                  >
+                    <v-card height="fit-content">
+                      <v-card-actions class="justify-end">
+                        <v-btn color="primary-dark" @click="advancedSettingsDialog = false">✖</v-btn>
+                      </v-card-actions>
+
+                      <v-card-title class="justify-center data-title">
+                        <span class="mr-2">Scaling setup</span>
+                        <v-tooltip bottom="" max-width="500px">
+                          <template v-slot:activator="{ on }">
+                            <v-icon v-on="on"> mdi-help-circle-outline </v-icon>
+                          </template>
+                          OpenCap uses data from the neutral pose to scale the musculoskeletal model to the anthropometry of the subject.
+                          By default, OpenCap assumes that the subject is standing with an upright posture and the feet pointing forward (i.e., straight back and no bending or rotation at the hips, knees, or ankles) as shown in the example neutral pose. These assumptions are modeled in the OpenSim scaling setup.
+                          If the subject cannot adopt this pose, you can select the "Any pose" scaling setup, which does not assume any specific posture but still requires all body segments to be visible by at least two cameras.
+                          We recommend using the default scaling setup unless the subject cannot adopt the upright standing neutral pose.
+                        </v-tooltip>
+                      </v-card-title>
+                      <v-card-text class="d-flex flex-column align-center checkbox-wrapper">
+                        <v-select
+                            v-model="scaling_setup"
+                            label="Select scaling setup"
+                            v-bind:items="scaling_setups"
+                          />
+                      </v-card-text>
+
+                      <v-card-title class="justify-center data-title">
+                        <span class="mr-2">Human pose estimation model</span>
+                        <v-tooltip bottom="" max-width="500px">
+                          <template v-slot:activator="{ on }">
+                            <v-icon v-on="on"> mdi-help-circle-outline </v-icon>
+                          </template>
+                          OpenCap supports two human pose estimation models: OpenPose and HRNet. We recommend using OpenPose for computation speed, but both models provide similar accuracy.
+                          OpenPose is restricted to academic or non-profit organization non-commercial research use (consult the license at https://github.com/CMU-Perceptual-Computing-Lab/openpose/blob/master/LICENSE).
+                          HRNet, as implemented by Open-MMLab, has a permissive Apache 2.0 license (consult the license at https://github.com/open-mmlab/mmpose/blob/master/LICENSE).
+                          Please ensure that you have the rights to use the model you select. The OpenCap authors deny any responsibility regarding license infringement.
+                        </v-tooltip>
+                      </v-card-title>
+                      <v-card-text class="d-flex flex-column align-center checkbox-wrapper">
+                        <v-select
+                            v-model="pose_model"
+                            label="Select human pose estimation model"
+                            v-bind:items="pose_models"
+                          />
+                      </v-card-text>
+        
+                      <v-card-title class="justify-center data-title">
+                        Framerate
+                      </v-card-title>
+                      <v-card-text class="d-flex flex-column align-center checkbox-wrapper">
+                        <v-select
+                            v-model="framerate"
+                            label="Select framerate"
+                            v-bind:items="framerates_available"
+                            @change="updateFrequency"
+                          />
+                      </v-card-text>
+
+                      <v-card-title class="justify-center data-title">
+                        <span class="mr-2">Musculoskeletal model</span>
+                        <v-tooltip bottom="" max-width="500px">
+                          <template v-slot:activator="{ on }">
+                            <v-icon v-on="on"> mdi-help-circle-outline </v-icon>
+                          </template>
+                          Full body model: Musculoskeletal model with 33 degrees of freedom from Lai et al. 2017 (https://pubmed.ncbi.nlm.nih.gov/28900782/) with modified hip abductor muscle paths from Uhlrich et al. 2022 (https://pubmed.ncbi.nlm.nih.gov/35798755/). Recommended for primarily lower extremity tasks (e.g., gait).
+                          <br><br>
+                          Full body model with ISB shoulder: Incorporates a 6 degree-of-freedom shoulder complex joint. It incorporates a scapulothoracic body with 3 translational degrees of freedom relative to the torso. The glenohumoral joint uses the Y-X-Y rotation sequence (elevation plane, elevation, rotation) recommended by the ISB (https://pubmed.ncbi.nlm.nih.gov/15844264/). Recommended for upper extremity tasks (e.g., pitching).
+                        </v-tooltip>
+                      </v-card-title>
+                      <v-card-text class="d-flex flex-column align-center checkbox-wrapper">
+                        <v-select
+                            v-model="openSimModel"
+                            label="Select musculoskeletal model"
+                            v-bind:items="openSimModels"
+                          />
+                      </v-card-text>
+
+                      <v-card-title class="justify-center data-title">
+                        <span class="mr-2">Marker augmenter model</span>
+                        <v-tooltip bottom="" max-width="500px">
+                          <template v-slot:activator="{ on }">
+                            <v-icon v-on="on"> mdi-help-circle-outline </v-icon>
+                          </template>
+                          OpenCap uses an LSTM model, also called marker augmenter model, to predict the 3D position of 43 anatomical markers from the 3D position of 20 video keypoints (https://www.biorxiv.org/content/10.1101/2022.07.07.499061v1). 
+                          The anatomical markers are used as input to OpenSim to compute joint angles using inverse kinematics.
+                          <br><br>
+                          The latest model (v0.3, default) is more accurate and more robust to different activities than v0.2. We recommend using it for new studies. 
+                          It was trained on 1475 hours of motion capture data and resulted in an RMSE of 4.4 +/- 0.3 deg (OpenPose) and 4.1 +/- 0.3 deg (HRnet) for joint angles across 18 degrees of freedom.
+                          <br><br>                  
+                          The original model (v0.2) underwent training using 708 hours of motion capture data, yielding an RMSE of 4.8 +/- 0.2 deg (OpenPose and HRNet) for joint angles across 18 degrees of freedom. 
+                          <br><br>
+                          The performance evaluation was conducted in comparison to marker-based motion capture using data from 10 subjects performing 4 different types of activities (walking, squatting, sit-to-stand, and drop jumps). 
+                          The dataset used for training the latest model (v0.3) contains data from more subjects and from a more diverse set of tasks; model v0.3 is therefore expected to be more accurate for a wider variety of tasks and to yield more accurate results.
+                          We recommend using v0.3 for new studies but warn users that we might still adjust the model in the future. 
+                          If you would like to use the model that was default prior to 07-30-2023, select v0.2.
+                        </v-tooltip>
+                      </v-card-title>
+                      <v-card-text class="d-flex flex-column align-center checkbox-wrapper">
+                        <v-select
+                            v-model="augmenter_model"
+                            label="Select marker augmenter model"
+                            v-bind:items="augmenter_models"
+                          />
+                      </v-card-text>
+
+                      <v-card-title class="justify-center data-title">
+                        <span class="mr-2">Filter frequency</span>
+                        <v-tooltip bottom="" max-width="500px">
+                          <template v-slot:activator="{ on }">
+                            <v-icon v-on="on"> mdi-help-circle-outline </v-icon>
+                          </template>
+                          OpenCap uses a low-pass Butterworth filter to smooth the 2D video keypoints. The filter frequency is the cutoff frequency of the filter.
+                          <br><br>                  
+                          By default, OpenCap uses a filter frequency of half the framerate (if the framerate is 60fps, the filter frequency is 30Hz), except for gait activities, for which the filter frequency is 12Hz.
+                          <br><br>
+                          You can here enter a different filter frequency. WARNING: this filter frequency will be applied to ALL motion trials of your session. As per the Nyquist Theorem, the filter frequency should be less than half the framerate.
+                          If you enter a filter frequency higher than half the framerate, we will use half the framerate as the filter frequency instead.
+                          <br><br>
+                          We recommend consulting the literature to find a suitable filter frequency for your specific tasks. If you are unsure, we recommend using the default filter frequency.
+                        </v-tooltip>
+                      </v-card-title>
+                      <v-card-text class="d-flex flex-column align-center checkbox-wrapper">
+                        <v-combobox
+                        :key="componentKey"
+                        v-model="tempFilterFrequency"
+                        label="Enter frequency (Hz) or choose default"
+                        :items="filter_frequencies"
+                        :allow-custom="true"
+                        :return-object="false"
+                        @change="validateAndSetFrequency"
+                        item-text="text"
+                        item-value="value"
+                        ></v-combobox>
+                      </v-card-text>
+                    </v-card>
+                  </v-dialog>
+                </div>
+              </template>
+            </div>
+          </div>
+
+          <v-card v-if="!isMonocularMode" class="step-4-2 ml-4 d-flex images-box right-column">
+            <v-card class="mb-0">
+              <v-card-text style="padding-top: 5px; padding-bottom: 0; font-size: 16px;">
+              <p>{{ n_videos_uploaded }} of {{ n_calibrated_cameras }} videos uploaded</p>
+              </v-card-text>
+            </v-card>
+
+            <v-card-title class="justify-center">
+              Record neutral pose
+            </v-card-title>
+            
+            <v-card-text class="d-flex justify-center align-center">
+              <div class="d-flex flex-column mr-4">
+                <ul>
+                  <li>
+                    The subject should adopt the example neutral pose
+                    <ul>
+                      <li class="space-above-small">Upright standing posture with feet pointing forward</li>
+                      <li class="space-above-small">Straight back and no bending or rotation at the hips, knees, or ankles</li>
+                    </ul>
+                  </li>
+                  <li class="space-above-small">The subject should stand still</li>
+                  <li class="space-above-small">
+                    The subject should be visible by all cameras 
+                    <ul>
+                      <li class="space-above-small">Nothing in the way
+                        of cameras view when hitting Record</li>
+                    </ul>
+                  </li>
+                </ul>
+              </div>
+              <div class="d-flex flex-column align-center ">
+                <span class="sub-header" style="font-size: 18px;">Example neutral pose</span>
+                <ExampleImage
+                  image="/images/step-4/big_good_triangle.jpg"
+                  :width="256"
+                  :height="341"
+                  good
+                />
+              </div>
+            </v-card-text>
+            <v-card-title class="justify-center" style="font-size: 18px; word-break: keep-all;">
+              If the subject cannot adopt the example neutral pose, select "Any pose" scaling setup under Advanced Settings
+            </v-card-title>
+          </v-card>
+        </div>
+      </div>
+
+      <!-- Custom navigation bar for Neutral page -->
+      <div class="custom-navigation d-flex justify-space-between align-center pa-4">
+        <div> <!-- Left slot for Back button -->
+          <v-btn @click="navigateBack">
+            Back
+          </v-btn>
+        </div>
+        <div> <!-- Right slot for action buttons -->
+          <v-btn
+            v-if="hasMonoAccess"
+            class="mr-2"
+            color="warning"
+            :disabled="busy || disabledNextButton"
+            @click="skipProcessing">
+            Next to monocular
+          </v-btn>
+          <v-btn
+            :disabled="busy || disabledNextButton"
+            :loading="busy && !imgs"
+            @click="onNext">
+            {{ rightButtonCaption }}
+          </v-btn>
+        </div>
+      </div>
+    </div>
   
     <DialogComponent
       ref="dialogRef"
@@ -395,6 +385,7 @@ export default {
   },
   data() {
     return {
+      isMonocularMode: false,
       formErrors: {
         name: null,
         weight: null,
@@ -405,13 +396,10 @@ export default {
       },
       advancedSettingsDialog: false,
       selected: null,
-
       subject_query: "",
-      // subject_search: "",
       subject_loading: false,
       subject_start: 0,
       loaded_subjects: [],
-
       sessionName: "",
       subject: null,
       identifier: "",
@@ -469,19 +457,15 @@ export default {
         processing: "Processing",
       },
       checkboxRule: (v) => !!v || 'The subject must agree to continue!',
-
       n_calibrated_cameras: 0,
       n_cameras_connected: 0,
       n_videos_uploaded: 0,
-
-      tempFilterFrequency: 'default', // Temporary input holder
+      tempFilterFrequency: 'default',
       componentKey: 0,
-
       isAuditoryFeedbackEnabled: false,
     };
   },
   created() {
-    // Load the initial value from localStorage
     const storedValue = localStorage.getItem("auditory_feedback");
     this.isAuditoryFeedbackEnabled = storedValue === "true";
   },
@@ -508,7 +492,6 @@ export default {
     imgCols() {
       let res = [];
       let iRes = null;
-      let i = 0;
       for (let i = 0; i < this.imgs.length; i++) {
         if (i % 2 == 0) {
           iRes = [this.imgs[i]];
@@ -545,15 +528,17 @@ export default {
     }
     },
     hasMonoAccess() {
-      const allowedUsers = ['selimgilon', 'suhlrich', 'antoine'];
+      const allowedUsers = ['selimgilon', 'suhlrich', 'antoine', 'dev_user'];
       const currentUser = this.username || localStorage.getItem('auth_user');
       return allowedUsers.includes(currentUser);
     },
   },
   async mounted() {
+    if (this.$route.query.isMono === 'true') {
+      this.isMonocularMode = true;
+    }
     apiInfo("You can now record a neutral pose different than the upright standing pose (e.g., sitting). Select 'Any pose' 'Advanced Settings'.", 8000);
     this.loadSession(this.$route.params.id)
-    // this.loadSubjects()
     if (this.$route.query.autoRecord) {
       this.onNext();
     }
@@ -565,7 +550,6 @@ export default {
   },
   watch: {
     subject (newVal, oldVal) {
-      console.log('watch subject', newVal, oldVal)
       if (newVal === null) {
         this.clearSubjectSearch()
       }
@@ -574,15 +558,19 @@ export default {
   methods: {
     ...mapMutations("data", ["setNeutral", "setTrialId"]),
     ...mapActions("data", ["loadSubjects", "loadSession"]),
+    navigateBack() {
+      if (this.isMonocularMode) {
+        this.$router.push('/connect-devices');
+      } else {
+        this.$router.push(`/${this.session.id}/calibration`);
+      }
+    },
     isSomeInputInvalid(state, input) {
       setTimeout(() => {
         this.formErrors[input] = state;
       },0)
     },
     loadSubjectsList (append_result = false) {
-      console.log('loading subjects:', this.subject_search, ' - ', append_result)
-      console.log('subject=', this.subject)
-
       this.subject_loading = true
       let data = {
         search: this.subject_search,
@@ -590,13 +578,12 @@ export default {
         quantity: 40,
         simple: 'true'
       }
-      let res = axios.get('/subjects/', {params: data}).then((res) => {
+      axios.get('/subjects/', {params: data}).then((res) => {
         if (append_result) {
           this.loaded_subjects = [...this.loaded_subjects, ...res.data.subjects]
         } else {
           this.loaded_subjects = res.data.subjects
         }
-        // this.subject_loading = false
         this.subject_loading = false
       }).catch((error) => {
         this.subject_loading = false
@@ -616,7 +603,6 @@ export default {
       this.loadSubjectsList(false)
     },
     submitAddSubject (data) {
-      console.log('submitAddSubject', data)
       let obj = {
         id: data.id,
         display_name: `${data.name} (${data.weight} Kg, ${data.height} m, ${data.birth_year})`,
@@ -625,8 +611,6 @@ export default {
       this.subject = obj
     },
     reloadSubjects() {
-      console.log('reloading subjects')
-      // this.loadSubjects()
     },
     openNewSubjectPopup() {
         this.$refs.dialogRef.edit_dialog = true
@@ -665,7 +649,6 @@ export default {
     },
     async onNext() {
       if (this.imgs) {
-        // Confirm
         this.$router.push({
           name: "Session",
           params: {
@@ -682,15 +665,9 @@ export default {
           if (await this.$refs.observer.validate()) {
             apiInfo("Recording...")
             this.lastPolledStatus = "";
-            // Record press
             this.busy = true;
             this.setNeutral({
                 subject: this.subject,
-              // identifier: this.identifier,
-              // weight: this.weight,
-              // height: this.height,
-              // sex: this.sex,
-              // gender: this.gender,
               data_sharing: this.data_sharing,
               scaling_setup: this.scaling_setup,
               pose_model: this.pose_model,
@@ -700,15 +677,10 @@ export default {
               filter_frequency: this.filter_frequency,
             });
             try {
-              const resUpdate = await axios.get(
+              await axios.get(
                 `/sessions/${this.session.id}/set_metadata/`,
                 {
                   params: {
-                    // subject_id: this.identifier,
-                    // subject_mass: this.weight,
-                    // subject_height: this.height,
-                    // subject_sex: this.sex,
-                    // subject_gender: this.gender,
                     settings_data_sharing: this.data_sharing,
                     settings_scaling_setup: this.scaling_setup,
                     settings_pose_model: this.pose_model,
@@ -721,11 +693,11 @@ export default {
                 }
               );
 
-              const resSubject = await axios.get(
+              await axios.get(
                   `/sessions/${this.session.id}/set_subject/`,
                   {
                       params: {
-                          subject_id: this.subject.id,
+                          subject_id: this.identifier,
                       }
                   }
               )
@@ -755,22 +727,9 @@ export default {
     },
     async pollStatus() {
       try {
-        //const res = await axios.get(`/sessions/1966df9a-0a60-4365-9404-43e53750b784/neutral_img/`)
         const res = await axios.get(
           `/sessions/${this.session.id}/neutral_img/`
         );
-        // test
-        /*
-        this.imgs = [
-          '/images/neutral_pose.png',
-          '/images/neutral_pose.png',
-          '/images/neutral_pose.png',
-          '/images/neutral_pose.png',
-          '/images/neutral_pose.png',
-          //'/images/neutral_pose.png'
-        ]
-        this.busy = false
-        */
         switch (res.data.status) {
           case "done": {
             this.$toasted.clear()
@@ -780,8 +739,6 @@ export default {
                 id: this.session.id,
               },
             });
-            //this.imgs = res.data.img
-            //this.busy = false
             break;
           }
           case "error": {
@@ -836,10 +793,8 @@ export default {
     },
     async getAvailableFramerates() {
       const session_settings = await axios.get(`/sessions/${this.session.id}/get_session_settings/`)
-      // If the session has framerates.
       if('data' in session_settings && 'framerates' in session_settings.data) {
         this.framerates_available = []
-        // Push them to available framerates
         session_settings.data.framerates.forEach(element => {
           if(element == 60) {
             this.framerates_available.push({"text": "60fps (max recording time: 60s, default)", "value": 60})
@@ -850,7 +805,6 @@ export default {
           }
         });
       }
-      // If not, or we did not recognize them (different to 60, 120 or 240), set 60 as default.
       if(this.framerates_available.length == 0) {
         this.framerates_available.push({"text": "60fps (max recording time: 60s, default)", "value": 60})
       }
@@ -893,8 +847,7 @@ export default {
       if (await this.$refs.observer.validate()) {
         this.busy = true;
         try {
-          // Set metadata without checking cameras
-          const resUpdate = await axios.get(
+          await axios.get(
             `/sessions/${this.session.id}/set_metadata/`,
             {
               params: {
@@ -910,8 +863,7 @@ export default {
             }
           );
 
-          // Set subject
-          const resSubject = await axios.get(
+          await axios.get(
             `/sessions/${this.session.id}/set_subject/`,
             {
               params: {
@@ -938,6 +890,73 @@ export default {
 </script>
 
 <style lang="scss">
+.neutral-wrapper {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  overflow-x: hidden; /* Prevent horizontal scrolling */
+}
+
+.neutral-content {
+  flex: 1; /* Changed from flex-grow: 1 to flex: 1 for brevity, same effect */
+  overflow-y: auto;
+  overflow-x: hidden; /* Prevent horizontal scrolling */
+}
+
+.custom-navigation {
+  width: 100%;
+  /* Vuetify pa-4 is 16px padding all around. We apply it via class in template */
+  /* margin-top: 16px; /* If using pa-4, margin might not be needed or can be adjusted */
+  /* padding-bottom: 16px; */
+  box-sizing: border-box; /* Ensure padding is included in width/height */
+  position: sticky;
+  bottom: 0;
+  background-color: transparent; 
+  z-index: 10; 
+}
+
+.neutral-layout {
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  flex-wrap: nowrap; /* Prevent wrapping */
+  
+  @media (max-width: 960px) {
+    flex-direction: column;
+  }
+}
+
+.left-column {
+  flex: 0 0 48%; 
+  max-width: 48%;
+  overflow-y: auto;
+  
+  &.full-width {
+    flex: 1 1 100%;
+    max-width: 100%;
+    padding-right: 0;
+  }
+
+  @media (max-width: 960px) {
+    flex: 1;
+    max-width: 100%;
+    padding-right: 0; 
+  }
+}
+
+.right-column {
+  flex-grow: 1;   
+  flex-basis: 0;    
+  
+  @media (max-width: 960px) {
+    flex: 1;
+    max-width: 100%;
+    margin-left: 0 !important; 
+    margin-top: 16px;
+  }
+}
+
 .step-4-1 {
   flex: 0 0 50%;
   li {
@@ -947,6 +966,7 @@ export default {
     }
   }
 }
+
 .step-4-2 {
   flex-grow: 1;
   h1 {
@@ -967,10 +987,6 @@ export default {
   column-gap: 16px;
 }
 
-//.subject-title {
-//  padding-bottom: 0;
-//}
-
 .images-box {
   display: flex;
   flex-direction: column;
@@ -980,10 +996,6 @@ export default {
     font-size: 16px;
   }
 }
-
-//.checkbox-wrapper {
-//  padding-top: 0;
-//}
 
 .checkbox-box > div {
   margin-top: 0;
@@ -1018,8 +1030,4 @@ export default {
   font-size: 20px;  /* Adjust the font size as needed */
   font-weight: bold;
 }
-
-//.data-title {
-//  padding-bottom: 7px;
-//}
 </style>

--- a/src/components/pages/Neutral.vue
+++ b/src/components/pages/Neutral.vue
@@ -342,7 +342,7 @@
         </div>
         <div> <!-- Right slot for action buttons -->
           <v-btn
-            v-if="hasMonoAccess"
+            v-if="hasMonoAccess" 
             class="mr-2"
             color="warning"
             :disabled="busy || disabledNextButton"
@@ -350,6 +350,7 @@
             Next to monocular
           </v-btn>
           <v-btn
+            v-if="!isMonocularMode" 
             :disabled="busy || disabledNextButton"
             :loading="busy && !imgs"
             @click="onNext">


### PR DESCRIPTION
The neutral page accepts an argument 'isMono', if true is doesn't show the neutral container but only the relevant things. See screenshot below for an example. Back button is now correct as well. The buttons were not visible on the ipad so I fixed the UI to make it visible.
![IMG_1018](https://github.com/user-attachments/assets/090a583a-a321-42b5-886a-923a13eb3edb)
