### PR TITLE
Added retry util function. Used in calibration. Added tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,15 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "serve": "HOST=0.0.0.0 vue-cli-service serve",
+    "serve": "cross-env HOST=0.0.0.0 vue-cli-service serve",
     "build": "vue-cli-service build",
-    "lint": "vue-cli-service lint"
+    "lint": "vue-cli-service lint",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage"
   },
   "dependencies": {
+    "@types/jest": "^30.0.0",
     "@fortawesome/fontawesome-free": "^6.4.0",
     "@mdi/font": "^3.6.95",
     "axios": "^0.21.0",
@@ -34,12 +38,16 @@
     "vuex": "^3.6.2"
   },
   "devDependencies": {
+    "@types/jest": "^30.0.0",
     "@vue/cli-plugin-babel": "~4.5.0",
     "@vue/cli-plugin-eslint": "~4.5.0",
     "@vue/cli-service": "~4.5.0",
+    "axios-mock-adapter": "^2.1.0",
     "babel-eslint": "^10.1.0",
+    "cross-env": "^10.1.0",
     "eslint": "^6.7.2",
     "eslint-plugin-vue": "^6.2.2",
+    "jest": "^30.3.0",
     "sass": "^1.39.0",
     "sass-loader": "^10.2.0",
     "vue-cli-plugin-vuetify": "~2.0.8",
@@ -66,5 +74,21 @@
     "> 1%",
     "last 2 versions",
     "not dead"
-  ]
+  ],
+  "jest": {
+    "testEnvironment": "node",
+    "testMatch": [
+      "**/tests/**/*.test.js"
+    ],
+    "moduleNameMapper": {
+      "^@/(.*)$": "<rootDir>/src/$1"
+    },
+    "collectCoverageFrom": [
+      "src/network.js",
+      "!**/node_modules/**",
+      "!**/tests/**"
+    ],
+    "coverageReporters": ["text", "lcov", "html"],
+    "verbose": true
+  }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
-    "@types/jest": "^30.0.0",
     "@fortawesome/fontawesome-free": "^6.4.0",
     "@mdi/font": "^3.6.95",
     "axios": "^0.21.0",

--- a/src/components/pages/Calibration.vue
+++ b/src/components/pages/Calibration.vue
@@ -121,6 +121,7 @@ import {mapActions, mapMutations, mapState} from 'vuex'
 import { apiError, apiSuccess, apiErrorRes, apiInfo, clearToastMessages } from '@/util/ErrorMessage.js'
 import MainLayout from '@/layout/MainLayout'
 import { playCalibrationFinishedSound } from "@/util/SoundMessage.js";
+import { makeRequestWithRetry } from "@/util/network.js";
 
 export default {
   name: 'Calibration',
@@ -180,7 +181,7 @@ export default {
           placement: this.placement
         })
         try {
-          const resUpdate = await axios.get(`/sessions/${this.session.id}/set_metadata/`, {
+          const resUpdate = await makeRequestWithRetry('GET', `/sessions/${this.session.id}/set_metadata/`, {
             params: {
               cb_rows: this.rows,
               cb_cols: this.cols,
@@ -189,7 +190,7 @@ export default {
               }
             })
 
-          const res = await axios.get(`/sessions/${this.session.id}/record/`, {
+          const res = await makeRequestWithRetry('GET', `/sessions/${this.session.id}/record/`, {
             params: {
               name: 'calibration',
             }
@@ -204,13 +205,13 @@ export default {
     },
     async pollStatus() {
       try {
-        const res = await axios.get(`/sessions/${this.session.id}/calibration_img/`)
+        const res = await makeRequestWithRetry('GET', `/sessions/${this.session.id}/calibration_img/`)
         switch (res.data.status) {
           case "done": {
             clearTimeout(this.timeoutID);
             clearToastMessages()
 
-            const resCalibratedCameras = await axios.get(`/sessions/${this.$route.params.id}/get_n_calibrated_cameras/`, {})
+            const resCalibratedCameras = await makeRequestWithRetry('GET', `/sessions/${this.$route.params.id}/get_n_calibrated_cameras/`, {})
 
             this.n_calibrated_cameras = resCalibratedCameras.data.data
 
@@ -231,7 +232,7 @@ export default {
           case "error": {
             clearTimeout(this.timeoutID);
             clearToastMessages()
-            const res_trial = await axios.get(`/trials/${this.trialId}/`)
+            const res_trial = await makeRequestWithRetry('GET', `/trials/${this.trialId}/`)
             apiErrorRes(res_trial, 'Finished with error')
             this.busy = false;
 
@@ -243,7 +244,7 @@ export default {
               res.data.status === "processing" &&
               res.data.status !== this.lastPolledStatus
             ) {
-              const resCalibratedCameras = await axios.get(`/sessions/${this.$route.params.id}/get_n_calibrated_cameras/`, {})
+              const resCalibratedCameras = await makeRequestWithRetry('GET', `/sessions/${this.$route.params.id}/get_n_calibrated_cameras/`, {})
 
               this.n_calibrated_cameras = resCalibratedCameras.data.data
 
@@ -266,7 +267,7 @@ export default {
         }
 
         // Get n_cameras_connected.
-        const res_status = await axios.get(`/sessions/${this.session.id}/status/`, {})
+        const res_status = await makeRequestWithRetry('GET', `/sessions/${this.session.id}/status/`, {})
 
         this.n_videos_uploaded = res_status.data.n_videos_uploaded
         this.n_cameras_connected = res_status.data.n_cameras_connected

--- a/src/components/pages/Calibration.vue
+++ b/src/components/pages/Calibration.vue
@@ -121,7 +121,7 @@ import {mapActions, mapMutations, mapState} from 'vuex'
 import { apiError, apiSuccess, apiErrorRes, apiInfo, clearToastMessages } from '@/util/ErrorMessage.js'
 import MainLayout from '@/layout/MainLayout'
 import { playCalibrationFinishedSound } from "@/util/SoundMessage.js";
-import { makeRequestWithRetry } from "@/util/network.js";
+import { axiosGetWithRetry } from "@/util/network.js";
 
 export default {
   name: 'Calibration',
@@ -181,7 +181,7 @@ export default {
           placement: this.placement
         })
         try {
-          const resUpdate = await makeRequestWithRetry('GET', `/sessions/${this.session.id}/set_metadata/`, {
+          const resUpdate = await axiosGetWithRetry(`/sessions/${this.session.id}/set_metadata/`, {
             params: {
               cb_rows: this.rows,
               cb_cols: this.cols,
@@ -190,7 +190,7 @@ export default {
               }
             })
 
-          const res = await makeRequestWithRetry('GET', `/sessions/${this.session.id}/record/`, {
+          const res = await axiosGetWithRetry(`/sessions/${this.session.id}/record/`, {
             params: {
               name: 'calibration',
             }
@@ -205,13 +205,13 @@ export default {
     },
     async pollStatus() {
       try {
-        const res = await makeRequestWithRetry('GET', `/sessions/${this.session.id}/calibration_img/`)
+        const res = await axiosGetWithRetry(`/sessions/${this.session.id}/calibration_img/`)
         switch (res.data.status) {
           case "done": {
             clearTimeout(this.timeoutID);
             clearToastMessages()
 
-            const resCalibratedCameras = await makeRequestWithRetry('GET', `/sessions/${this.$route.params.id}/get_n_calibrated_cameras/`, {})
+            const resCalibratedCameras = await axiosGetWithRetry(`/sessions/${this.$route.params.id}/get_n_calibrated_cameras/`, {})
 
             this.n_calibrated_cameras = resCalibratedCameras.data.data
 
@@ -232,7 +232,7 @@ export default {
           case "error": {
             clearTimeout(this.timeoutID);
             clearToastMessages()
-            const res_trial = await makeRequestWithRetry('GET', `/trials/${this.trialId}/`)
+            const res_trial = await axiosGetWithRetry(`/trials/${this.trialId}/`)
             apiErrorRes(res_trial, 'Finished with error')
             this.busy = false;
 
@@ -244,7 +244,7 @@ export default {
               res.data.status === "processing" &&
               res.data.status !== this.lastPolledStatus
             ) {
-              const resCalibratedCameras = await makeRequestWithRetry('GET', `/sessions/${this.$route.params.id}/get_n_calibrated_cameras/`, {})
+              const resCalibratedCameras = await axiosGetWithRetry(`/sessions/${this.$route.params.id}/get_n_calibrated_cameras/`, {})
 
               this.n_calibrated_cameras = resCalibratedCameras.data.data
 
@@ -267,7 +267,7 @@ export default {
         }
 
         // Get n_cameras_connected.
-        const res_status = await makeRequestWithRetry('GET', `/sessions/${this.session.id}/status/`, {})
+        const res_status = await axiosGetWithRetry(`/sessions/${this.session.id}/status/`, {})
 
         this.n_videos_uploaded = res_status.data.n_videos_uploaded
         this.n_cameras_connected = res_status.data.n_cameras_connected

--- a/src/util/network.js
+++ b/src/util/network.js
@@ -1,5 +1,6 @@
 // network.js
 import axios from 'axios';
+import {apiError} from './ErrorMessage';
 
 /**
  * Makes an HTTP request with retry logic.
@@ -9,9 +10,10 @@ import axios from 'axios';
  * @param {Object} options.headers - Headers to include
  * @param {Object} options.data - Data to send in the request body
  * @param {Object} options.params - URL query parameters
- * @param {number} options.retries - Number of retry attempts (default: 5)
+ * @param {number} options.retries - Number of retry attempts (after first try) (default: 5)
  * @param {number} options.backoffFactor - Backoff factor for exponential delays (default: 1)
  * @param {number} options.maxJitterMs - Maximum random jitter in milliseconds (default: 1000)
+ * @param {number} options.timeout - Overall timeout in milliseconds (default: null)
  * @returns {Promise<Object>} Axios response object
  */
 export async function makeRequestWithRetry(method, url, options = {}) {
@@ -21,21 +23,27 @@ export async function makeRequestWithRetry(method, url, options = {}) {
     params = null,
     retries = 5,
     backoffFactor = 1,
-    maxJitterMs = 1000
+    maxJitterMs = 1000,
+    timeout = null
   } = options;
 
   // Status codes that should trigger a retry
   const RETRYABLE_STATUS_CODES = [429, 500, 502, 503, 504];
 
-  // HTTP methods that are safe to retry (idempotent)
-  const IDEMPOTENT_METHODS = ['GET', 'HEAD', 'PUT', 'DELETE', 'OPTIONS', 'TRACE'];
-
   let lastError = null;
+  const overallStartTime = Date.now();
 
   for (let attempt = 0; attempt <= retries; attempt++) {
     const isFirstAttempt = attempt === 0;
     const attemptNumber = attempt + 1;
     const totalAttempts = retries + 1;
+
+    // Check if we've exceeded the overall timeout before making the request
+    if (timeout && (Date.now() - overallStartTime) >= timeout) {
+      console.log(`[Attempt ${attemptNumber}/${totalAttempts}] Request to ${method} ${url} - Timeout reached (${timeout}ms), stopping retries`);
+      apiError('The request took too long to complete. Please try again.');
+      throw new Error(`Request timeout after ${Date.now() - overallStartTime}ms (limit: ${timeout}ms)`);
+    }
 
     // For testing. Will print attempts and times in browser console.
     if (!isFirstAttempt) {
@@ -43,22 +51,32 @@ export async function makeRequestWithRetry(method, url, options = {}) {
     }
 
     try {
-      const startTime = Date.now();
-      
-      // Create axios config with start time for duration calculation
+      const requestStartTime = Date.now();
+
+      // Calculate remaining timeout for this individual request
+      let requestTimeout = undefined;
+      if (timeout) {
+        const elapsedTime = Date.now() - overallStartTime;
+        requestTimeout = Math.max(1000, timeout - elapsedTime);
+      }
+
+      // Create axios config
       const axiosConfig = {
         method,
         url,
-        headers,
         data,
-        params
+        params,
+        timeout: requestTimeout
       };
-      
-      // Store start time on config for error handling
-      axiosConfig.__startTime = startTime;
-      
+
+      // Only add headers if they're provided, otherwise it will overwrite default headers
+      // and the request will fail with error 403.
+      if (headers) {
+        axiosConfig.headers = headers;
+      }
+
       const response = await axios(axiosConfig);
-      const duration = Date.now() - startTime;
+      const duration = Date.now() - requestStartTime;
 
       console.log(`[Attempt ${attemptNumber}/${totalAttempts}] Request to ${method} ${url} succeeded in ${duration}ms`);
 
@@ -66,19 +84,34 @@ export async function makeRequestWithRetry(method, url, options = {}) {
       return response;
 
     } catch (error) {
-      // Calculate duration if available
-      // const duration = error.config && error.config.__startTime
-      //   ? Date.now() - error.config.__startTime
-      //   : 0;
-      
+
       lastError = error;
 
       // Check if we should retry
       const isLastAttempt = attempt === retries;
 
+      // Don't retry if we've exceeded the overall timeout
+      if (timeout && (Date.now() - overallStartTime) >= timeout) {
+        console.log(`[Attempt ${attemptNumber}/${totalAttempts}] Request to ${method} ${url} - Overall timeout reached (${timeout}ms), stopping retries`);
+        apiError('The request took too long to complete. Please try again.');
+        throw new Error(`Request timeout after ${Date.now() - overallStartTime}ms (limit: ${timeout}ms)`);
+      }
+
       if (isLastAttempt) {
         console.log(`[Attempt ${attemptNumber}/${totalAttempts}] Request to ${method} ${url} failed - No more retries`);
         // No more retries, throw the error
+        if (!error.response) {
+          apiError('There was a network error. Please check your internet connection and try again.');
+        } else if (error.response.status >= 500) {
+          apiError('The server encountered an error. Please try again later.');
+        } else if (error.response.status === 429) {
+          apiError('Too many requests. Please wait a moment and try again.');
+        } else if (error.response.status === 408) {
+          apiError('The request timed out. Please try again.');
+        } else {
+          apiError('An unexpected error occurred. Please try again.');
+        }
+
         throw error;
       }
 
@@ -96,23 +129,39 @@ export async function makeRequestWithRetry(method, url, options = {}) {
         shouldRetry = true;
         retryReason = `Status code ${error.response.status}`;
       }
-      // For non-retryable status codes (4xx client errors), only retry if:
-      // 1. The method is idempotent AND
-      // 2. The status code is not in the 4xx range (client errors)
+      // Check for 408 Request Timeout from server should be retried, as it is server timeout and not
+      // client timeout
+      else if (error.response.status === 408) {
+        shouldRetry = true;
+        retryReason = `Status code 408 (Request Timeout)`;
+      }
+      // For non-retryable status codes (4xx client errors)
       else if (error.response.status >= 400 && error.response.status < 500) {
         // Client errors - don't retry
         shouldRetry = false;
         retryReason = `Client error ${error.response.status}`;
-      }
-      // For other status codes (3xx, etc.) with idempotent methods
-      else if (IDEMPOTENT_METHODS.includes(method.toUpperCase())) {
-        shouldRetry = true;
-        retryReason = `Idempotent method ${method.toUpperCase()}`;
+      } else {
+        // Catch-all for any other status codes (e.g., 3xx, 1xx)
+        shouldRetry = false;
+        retryReason = `Unhandled status code ${error.response.status}`;
       }
 
       if (!shouldRetry) {
         console.log(`[Attempt ${attemptNumber}/${totalAttempts}] Request to ${method} ${url} failed with non-retryable error - ${error.response?.status || error.message}`);
         // Don't retry this error
+        if (error.response.status === 400) {
+          apiError('The request was invalid. Please check your input and try again.');
+        } else if (error.response.status === 401) {
+          apiError('Your session has expired. Please log in again.');
+        } else if (error.response.status === 403) {
+          apiError('You do not have permission to perform this action.');
+        } else if (error.response.status === 404) {
+          apiError('The requested resource was not found.');
+        } else if (error.response.status === 409) {
+          apiError('There was a conflict with the current state. Please try again.');
+        } else if (error.response.status >= 400 && error.response.status < 500) {
+          apiError('There was an error with your request. Please try again.');
+        }
         throw error;
       }
 
@@ -123,6 +172,13 @@ export async function makeRequestWithRetry(method, url, options = {}) {
       // Add random jitter (0 to maxJitterMs)
       const jitterMs = Math.random() * maxJitterMs;
       const totalDelayMs = baseDelayMs + jitterMs;
+
+      // Check if the delay would exceed the overall timeout
+      if (timeout && (Date.now() - overallStartTime + totalDelayMs) >= timeout) {
+        console.log(`[Attempt ${attemptNumber}/${totalAttempts}] Request to ${method} ${url} - Next retry delay would exceed timeout, stopping`);
+        apiError('The request took too long to complete. Please try again.');
+        throw error;
+      }
 
       console.log(`[Attempt ${attemptNumber}/${totalAttempts}] Request to ${method} ${url} failed (${retryReason}) - Retrying in ${Math.round(totalDelayMs)}ms (base: ${Math.round(baseDelayMs)}ms + jitter: ${Math.round(jitterMs)}ms)`);
 

--- a/src/util/network.js
+++ b/src/util/network.js
@@ -16,7 +16,7 @@ import {apiError} from './ErrorMessage';
  * @param {number} options.timeout - Overall timeout in milliseconds (default: null)
  * @returns {Promise<Object>} Axios response object
  */
-export async function makeRequestWithRetry(method, url, options = {}) {
+export async function axiosRequestWithRetry(method, url, options = {}) {
   const {
     headers = null,
     data = null,
@@ -192,7 +192,7 @@ export async function makeRequestWithRetry(method, url, options = {}) {
 }
 
 export async function axiosGetWithRetry(url, config = {}, retryConfig = {}) {
-  return makeRequestWithRetry('GET', url, {
+  return axiosRequestWithRetry('GET', url, {
     ...config,  // headers, params, timeout from axios config
     ...retryConfig,  // retries, backoffFactor, etc.
     data: null  // GET doesn't have body
@@ -200,7 +200,7 @@ export async function axiosGetWithRetry(url, config = {}, retryConfig = {}) {
 }
 
 export async function axiosPostWithRetry(url, data = {}, config = {}, retryConfig = {}) {
-  return makeRequestWithRetry('POST', url, {
+  return axiosRequestWithRetry('POST', url, {
     ...config,
     data,
     ...retryConfig

--- a/src/util/network.js
+++ b/src/util/network.js
@@ -1,0 +1,136 @@
+// network.js
+import axios from 'axios';
+
+/**
+ * Makes an HTTP request with retry logic.
+ * @param {string} method - HTTP method ('GET', 'POST', 'PUT', etc.)
+ * @param {string} url - The endpoint URL
+ * @param {Object} options - Request options
+ * @param {Object} options.headers - Headers to include
+ * @param {Object} options.data - Data to send in the request body
+ * @param {Object} options.params - URL query parameters
+ * @param {number} options.retries - Number of retry attempts (default: 5)
+ * @param {number} options.backoffFactor - Backoff factor for exponential delays (default: 1)
+ * @param {number} options.maxJitterMs - Maximum random jitter in milliseconds (default: 1000)
+ * @returns {Promise<Object>} Axios response object
+ */
+export async function makeRequestWithRetry(method, url, options = {}) {
+  const {
+    headers = null,
+    data = null,
+    params = null,
+    retries = 5,
+    backoffFactor = 1,
+    maxJitterMs = 1000
+  } = options;
+
+  // Status codes that should trigger a retry
+  const RETRYABLE_STATUS_CODES = [429, 500, 502, 503, 504];
+
+  // HTTP methods that are safe to retry (idempotent)
+  const IDEMPOTENT_METHODS = ['GET', 'HEAD', 'PUT', 'DELETE', 'OPTIONS', 'TRACE'];
+
+  let lastError = null;
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const isFirstAttempt = attempt === 0;
+    const attemptNumber = attempt + 1;
+    const totalAttempts = retries + 1;
+
+    // For testing. Will print attempts and times in browser console.
+    if (!isFirstAttempt) {
+      console.log(`[Retry Attempt ${attemptNumber}/${totalAttempts}] Request to ${method} ${url} - Waiting before retry...`);
+    }
+
+    try {
+      const startTime = Date.now();
+      
+      // Create axios config with start time for duration calculation
+      const axiosConfig = {
+        method,
+        url,
+        headers,
+        data,
+        params
+      };
+      
+      // Store start time on config for error handling
+      axiosConfig.__startTime = startTime;
+      
+      const response = await axios(axiosConfig);
+      const duration = Date.now() - startTime;
+
+      console.log(`[Attempt ${attemptNumber}/${totalAttempts}] Request to ${method} ${url} succeeded in ${duration}ms`);
+
+      // Success - return the response
+      return response;
+
+    } catch (error) {
+      // Calculate duration if available
+      // const duration = error.config && error.config.__startTime
+      //   ? Date.now() - error.config.__startTime
+      //   : 0;
+      
+      lastError = error;
+
+      // Check if we should retry
+      const isLastAttempt = attempt === retries;
+
+      if (isLastAttempt) {
+        console.log(`[Attempt ${attemptNumber}/${totalAttempts}] Request to ${method} ${url} failed - No more retries`);
+        // No more retries, throw the error
+        throw error;
+      }
+
+      // Determine if we should retry this error
+      let shouldRetry = false;
+      let retryReason = '';
+
+      // Check for network errors (no response)
+      if (!error.response) {
+        shouldRetry = true;
+        retryReason = 'Network error';
+      }
+      // Check for retryable status codes (server errors or rate limiting)
+      else if (RETRYABLE_STATUS_CODES.includes(error.response.status)) {
+        shouldRetry = true;
+        retryReason = `Status code ${error.response.status}`;
+      }
+      // For non-retryable status codes (4xx client errors), only retry if:
+      // 1. The method is idempotent AND
+      // 2. The status code is not in the 4xx range (client errors)
+      else if (error.response.status >= 400 && error.response.status < 500) {
+        // Client errors - don't retry
+        shouldRetry = false;
+        retryReason = `Client error ${error.response.status}`;
+      }
+      // For other status codes (3xx, etc.) with idempotent methods
+      else if (IDEMPOTENT_METHODS.includes(method.toUpperCase())) {
+        shouldRetry = true;
+        retryReason = `Idempotent method ${method.toUpperCase()}`;
+      }
+
+      if (!shouldRetry) {
+        console.log(`[Attempt ${attemptNumber}/${totalAttempts}] Request to ${method} ${url} failed with non-retryable error - ${error.response?.status || error.message}`);
+        // Don't retry this error
+        throw error;
+      }
+
+      // Calculate delay with exponential backoff
+      // Formula: backoffFactor * (2^(attempt-1)) * 1000
+      const baseDelayMs = backoffFactor * Math.pow(2, attempt - 1) * 1000;
+
+      // Add random jitter (0 to maxJitterMs)
+      const jitterMs = Math.random() * maxJitterMs;
+      const totalDelayMs = baseDelayMs + jitterMs;
+
+      console.log(`[Attempt ${attemptNumber}/${totalAttempts}] Request to ${method} ${url} failed (${retryReason}) - Retrying in ${Math.round(totalDelayMs)}ms (base: ${Math.round(baseDelayMs)}ms + jitter: ${Math.round(jitterMs)}ms)`);
+
+      // Wait before retrying
+      await new Promise(resolve => setTimeout(resolve, totalDelayMs));
+    }
+  }
+
+  // This should never be reached, but just in case
+  throw lastError;
+}

--- a/src/util/network.js
+++ b/src/util/network.js
@@ -103,9 +103,9 @@ export async function makeRequestWithRetry(method, url, options = {}) {
         if (!error.response) {
           apiError('There was a network error. Please check your internet connection and try again.');
         } else if (error.response.status >= 500) {
-          apiError('The server encountered an error. Please try again later.');
+          apiError('The server encountered an error. Please try again.');
         } else if (error.response.status === 429) {
-          apiError('Too many requests. Please wait a moment and try again.');
+          apiError('Too many requests. Please wait a moment and try again later.');
         } else if (error.response.status === 408) {
           apiError('The request timed out. Please try again.');
         } else {
@@ -189,4 +189,20 @@ export async function makeRequestWithRetry(method, url, options = {}) {
 
   // This should never be reached, but just in case
   throw lastError;
+}
+
+export async function axiosGetWithRetry(url, config = {}, retryConfig = {}) {
+  return makeRequestWithRetry('GET', url, {
+    ...config,  // headers, params, timeout from axios config
+    ...retryConfig,  // retries, backoffFactor, etc.
+    data: null  // GET doesn't have body
+  });
+}
+
+export async function axiosPostWithRetry(url, data = {}, config = {}, retryConfig = {}) {
+  return makeRequestWithRetry('POST', url, {
+    ...config,
+    data,
+    ...retryConfig
+  });
 }

--- a/src/util/network.js
+++ b/src/util/network.js
@@ -192,17 +192,39 @@ export async function axiosRequestWithRetry(method, url, options = {}) {
 }
 
 export async function axiosGetWithRetry(url, config = {}, retryConfig = {}) {
+  // Default retry configuration for GET requests
+  const defaultGetRetryConfig = {
+    retries: 4,
+    backoffFactor: 0.5,
+    maxJitterMs: 200,
+    timeout: 10000
+  };
+
+  // Merge provided retryConfig with defaults (provided config takes precedence and overrides defaults)
+  const mergedRetryConfig = { ...defaultGetRetryConfig, ...retryConfig };
+
   return axiosRequestWithRetry('GET', url, {
     ...config,  // headers, params, timeout from axios config
-    ...retryConfig,  // retries, backoffFactor, etc.
+    ...mergedRetryConfig, // retries, backoffFactor, etc.
     data: null  // GET doesn't have body
   });
 }
 
 export async function axiosPostWithRetry(url, data = {}, config = {}, retryConfig = {}) {
+  // Default retry configuration for POST requests
+  const defaultPostRetryConfig = {
+    retries: 3,
+    backoffFactor: 1,
+    maxJitterMs: 500,
+    timeout: 30000
+  };
+
+  // Merge provided retryConfig with defaults (provided config takes precedence and overrides defaults)
+  const mergedRetryConfig = { ...defaultPostRetryConfig, ...retryConfig };
+
   return axiosRequestWithRetry('POST', url, {
-    ...config,
-    data,
-    ...retryConfig
+    ...config, // headers, params, timeout from axios config
+    data, // data included in the request
+    ...mergedRetryConfig // retries, backoffFactor, etc.
   });
 }

--- a/tests/network.test.js
+++ b/tests/network.test.js
@@ -318,6 +318,110 @@ describe('makeRequestWithRetry', () => {
     });
   });
 
+  describe('timeout parameter', () => {
+    it('should stop retrying when overall timeout is reached', async () => {
+      mockAxios.onGet('/api/slow').reply(500);
+
+      const startTime = Date.now();
+
+      await expect(makeRequestWithRetry('GET', '/api/slow', {
+        retries: 5,
+        backoffFactor: 0.5,
+        timeout: 1000
+      })).rejects.toThrow('Request failed with status code 500');
+
+      const duration = Date.now() - startTime;
+      expect(duration).toBeLessThan(1500);
+      expect(mockAxios.history.get.length).toBeLessThan(6);
+    });
+
+    it('should succeed if timeout not reached', async () => {
+      mockAxios
+        .onGet('/api/recovers')
+        .replyOnce(500)
+        .onGet('/api/recovers')
+        .replyOnce(200, { success: true });
+
+      const response = await makeRequestWithRetry('GET', '/api/recovers', {
+        retries: 3,
+        backoffFactor: 0.1,
+        timeout: 5000
+      });
+
+      expect(response.status).toBe(200);
+      expect(mockAxios.history.get.length).toBe(2);
+    });
+
+    it('should stop retrying when delay would exceed timeout', async () => {
+      mockAxios.onGet('/api/long-delay').reply(500);
+
+      const startTime = Date.now();
+
+      await expect(
+        makeRequestWithRetry('GET', '/api/long-delay', {
+          retries: 3,
+          backoffFactor: 2,
+          maxJitterMs: 0,
+          timeout: 1000
+        })
+      ).rejects.toThrow();
+
+      const duration = Date.now() - startTime;
+
+      expect(mockAxios.history.get.length).toBeLessThan(4);
+
+      expect(duration).toBeLessThan(1500);
+    });
+
+    it('should respect timeout on individual request', async () => {
+      mockAxios.onGet('/api/slow-response').timeout();
+
+      await expect(
+        makeRequestWithRetry('GET', '/api/slow-response', {
+          retries: 1,
+          backoffFactor: 0.1,
+          timeout: 500
+        })
+      ).rejects.toThrow();
+
+      expect(mockAxios.history.get.length).toBeGreaterThanOrEqual(1);
+      expect(mockAxios.history.get.length).toBeLessThanOrEqual(2);
+    });
+
+    it('should not retry after timeout even on retryable error', async () => {
+      let requestCount = 0;
+      mockAxios.onGet('/api/retry-after-timeout').reply(() => {
+        requestCount++;
+        return [500, { error: 'Server Error' }];
+      });
+
+      await expect(makeRequestWithRetry('GET', '/api/retry-after-timeout', {
+        retries: 10,
+        backoffFactor: 0.5,
+        timeout: 800
+      })).rejects.toThrow();
+
+      expect(requestCount).toBeLessThan(5);
+      expect(requestCount).toBeGreaterThan(0);
+    });
+
+    it('should work without timeout parameter (backward compatible)', async () => {
+      mockAxios
+        .onGet('/api/no-timeout')
+        .replyOnce(500)
+        .onGet('/api/no-timeout')
+        .replyOnce(200, { success: true });
+
+      const response = await makeRequestWithRetry('GET', '/api/no-timeout', {
+        retries: 1,
+        backoffFactor: 0.1
+      });
+
+      expect(response.status).toBe(200);
+      expect(mockAxios.history.get.length).toBe(2);
+    });
+    });
+
   describe('retry configuration options', () => {
     it('should respect custom retry count', async () => {
       mockAxios.onGet('/api/always-fail').reply(500);
@@ -380,7 +484,7 @@ describe('makeRequestWithRetry', () => {
         await new Promise(resolve => setTimeout(resolve, 100));
       }
 
-      // Delays should vary due to jitter
+      // Delays should vary due to jitter. Note: If randomness produces identical values by chance, this will fail.
       const uniqueDelays = new Set(delays.map(d => Math.floor(d / 100) * 100));
       expect(uniqueDelays.size).toBeGreaterThan(1);
     });
@@ -424,6 +528,7 @@ describe('makeRequestWithRetry', () => {
     });
 
     it('should handle timeout errors correctly', async () => {
+      // Simulates a network timeout (request aborted due to taking too long), not an HTTP 408 response from the server.
       mockAxios.onGet('/api/timeout').timeout();
 
       try {
@@ -433,6 +538,21 @@ describe('makeRequestWithRetry', () => {
         });
       } catch (error) {
         expect(error.code).toBe('ECONNABORTED');
+        expect(mockAxios.history.get.length).toBe(2);
+      }
+    });
+
+    it('should handle 408 errors correctly', async () => {
+      // Simulates a 408 Request Timeout error
+      mockAxios.onGet('/api/timeout').reply(408);
+
+      try {
+        await makeRequestWithRetry('GET', '/api/timeout', {
+          retries: 1,
+          backoffFactor: 0.1
+        });
+      } catch (error) {
+        expect(error.response.status).toBe(408);
         expect(mockAxios.history.get.length).toBe(2);
       }
     });

--- a/tests/network.test.js
+++ b/tests/network.test.js
@@ -1,0 +1,551 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { makeRequestWithRetry } from '../src/util/network.js';
+
+// Mock console.log to avoid cluttering test output
+global.console = {
+  log: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn()
+};
+
+describe('makeRequestWithRetry', () => {
+  let mockAxios;
+
+  beforeEach(() => {
+    mockAxios = new MockAdapter(axios);
+    jest.clearAllMocks();
+    jest.setTimeout(10000);
+  });
+
+  afterEach(() => {
+    mockAxios.restore();
+  });
+
+  describe('successful requests', () => {
+    it('should return response on first attempt for GET request', async () => {
+      const mockData = { id: 1, name: 'Test User' };
+      mockAxios.onGet('/api/users/1').reply(200, mockData);
+
+      const response = await makeRequestWithRetry('GET', '/api/users/1', { retries: 0 });
+
+      expect(response.status).toBe(200);
+      expect(response.data).toEqual(mockData);
+      expect(mockAxios.history.get.length).toBe(1);
+    });
+
+    it('should handle query parameters correctly', async () => {
+      mockAxios.onGet('/api/users').reply(200, { users: [] });
+
+      await makeRequestWithRetry('GET', '/api/users', {
+        params: { page: 1, limit: 10, sort: 'desc' },
+        retries: 0
+      });
+
+      expect(mockAxios.history.get[0].params).toEqual({
+        page: 1,
+        limit: 10,
+        sort: 'desc'
+      });
+    });
+
+    it('should handle request headers correctly', async () => {
+      mockAxios.onGet('/api/secure').reply(200, {});
+
+      await makeRequestWithRetry('GET', '/api/secure', {
+        headers: {
+          Authorization: 'Bearer token123',
+          'X-Custom-Header': 'custom-value'
+        },
+        retries: 0
+      });
+
+      expect(mockAxios.history.get[0].headers.Authorization).toBe('Bearer token123');
+      expect(mockAxios.history.get[0].headers['X-Custom-Header']).toBe('custom-value');
+    });
+
+    it('should handle POST requests with data payload', async () => {
+      const postData = { name: 'John Doe', email: 'john@example.com', age: 30 };
+      mockAxios.onPost('/api/users').reply(201, { id: 1, ...postData });
+
+      const response = await makeRequestWithRetry('POST', '/api/users', {
+        data: postData,
+        headers: { 'Content-Type': 'application/json' },
+        retries: 0
+      });
+
+      expect(response.status).toBe(201);
+      expect(JSON.parse(mockAxios.history.post[0].data)).toEqual(postData);
+      expect(response.data).toHaveProperty('id', 1);
+    });
+
+    it('should handle PUT requests with update data', async () => {
+      const updateData = { name: 'Jane Doe' };
+      mockAxios.onPut('/api/users/1').reply(200, { id: 1, ...updateData });
+
+      const response = await makeRequestWithRetry('PUT', '/api/users/1', {
+        data: updateData,
+        retries: 0
+      });
+
+      expect(response.status).toBe(200);
+      expect(JSON.parse(mockAxios.history.put[0].data)).toEqual(updateData);
+    });
+
+    it('should handle DELETE requests', async () => {
+      mockAxios.onDelete('/api/users/1').reply(204, null);
+
+      const response = await makeRequestWithRetry('DELETE', '/api/users/1', { retries: 0 });
+
+      expect(response.status).toBe(204);
+      expect(mockAxios.history.delete.length).toBe(1);
+    });
+  });
+
+  describe('retry logic for server errors', () => {
+    it('should retry on 500 error and succeed on second attempt', async () => {
+      mockAxios
+        .onGet('/api/unstable')
+        .replyOnce(500, { error: 'Internal Server Error' })
+        .onGet('/api/unstable')
+        .replyOnce(200, { success: true, data: 'Recovered data' });
+
+      const response = await makeRequestWithRetry('GET', '/api/unstable', {
+        retries: 1,
+        backoffFactor: 0.1
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.data).toEqual({ success: true, data: 'Recovered data' });
+      expect(mockAxios.history.get.length).toBe(2);
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining('Retrying')
+      );
+    });
+
+    it('should retry on 502 Bad Gateway error', async () => {
+      mockAxios
+        .onGet('/api/gateway')
+        .replyOnce(502, { error: 'Bad Gateway' })
+        .onGet('/api/gateway')
+        .replyOnce(200, { status: 'ok' });
+
+      const response = await makeRequestWithRetry('GET', '/api/gateway', {
+        retries: 1,
+        backoffFactor: 0.1
+      });
+
+      expect(response.status).toBe(200);
+      expect(mockAxios.history.get.length).toBe(2);
+    });
+
+    it('should retry on 503 Service Unavailable error', async () => {
+      mockAxios
+        .onGet('/api/service')
+        .replyOnce(503, { error: 'Service Unavailable' })
+        .onGet('/api/service')
+        .replyOnce(200, { healthy: true });
+
+      const response = await makeRequestWithRetry('GET', '/api/service', {
+        retries: 1,
+        backoffFactor: 0.1
+      });
+
+      expect(response.status).toBe(200);
+      expect(mockAxios.history.get.length).toBe(2);
+    });
+
+    it('should retry on 504 Gateway Timeout error', async () => {
+      mockAxios
+        .onGet('/api/timeout')
+        .replyOnce(504, { error: 'Gateway Timeout' })
+        .onGet('/api/timeout')
+        .replyOnce(200, { completed: true });
+
+      const response = await makeRequestWithRetry('GET', '/api/timeout', {
+        retries: 1,
+        backoffFactor: 0.1
+      });
+
+      expect(response.status).toBe(200);
+      expect(mockAxios.history.get.length).toBe(2);
+    });
+
+    it('should retry on 429 Too Many Requests error', async () => {
+      mockAxios
+        .onGet('/api/rate-limited')
+        .replyOnce(429, { error: 'Too Many Requests', retryAfter: 1 })
+        .onGet('/api/rate-limited')
+        .replyOnce(200, { success: true });
+
+      const response = await makeRequestWithRetry('GET', '/api/rate-limited', {
+        retries: 1,
+        backoffFactor: 0.1
+      });
+
+      expect(response.status).toBe(200);
+      expect(mockAxios.history.get.length).toBe(2);
+    });
+
+    it('should retry on network errors', async () => {
+      mockAxios
+        .onGet('/api/network-error')
+        .networkErrorOnce()
+        .onGet('/api/network-error')
+        .replyOnce(200, { recovered: true });
+
+      const response = await makeRequestWithRetry('GET', '/api/network-error', {
+        retries: 1,
+        backoffFactor: 0.1
+      });
+
+      expect(response.status).toBe(200);
+      expect(mockAxios.history.get.length).toBe(2);
+    });
+
+    it('should retry multiple times before succeeding', async () => {
+      mockAxios
+        .onGet('/api/retry-multiple')
+        .replyOnce(500)
+        .onGet('/api/retry-multiple')
+        .replyOnce(502)
+        .onGet('/api/retry-multiple')
+        .replyOnce(503)
+        .onGet('/api/retry-multiple')
+        .replyOnce(200, { finally: 'success' });
+
+      const response = await makeRequestWithRetry('GET', '/api/retry-multiple', {
+        retries: 3,
+        backoffFactor: 0.1
+      });
+
+      expect(response.status).toBe(200);
+      expect(mockAxios.history.get.length).toBe(4);
+    });
+  });
+
+  describe('non-retryable errors', () => {
+    it('should not retry on 400 Bad Request', async () => {
+      mockAxios.onGet('/api/bad-request').reply(400, { error: 'Bad Request' });
+
+      await expect(makeRequestWithRetry('GET', '/api/bad-request', {
+        retries: 3,
+        backoffFactor: 0.1
+      })).rejects.toThrow();
+
+      expect(mockAxios.history.get.length).toBe(1);
+    });
+
+    it('should not retry on 401 Unauthorized', async () => {
+      mockAxios.onGet('/api/unauthorized').reply(401, { error: 'Unauthorized' });
+
+      await expect(makeRequestWithRetry('GET', '/api/unauthorized', {
+        retries: 3,
+        backoffFactor: 0.1
+      })).rejects.toThrow();
+
+      expect(mockAxios.history.get.length).toBe(1);
+    });
+
+    it('should not retry on 403 Forbidden', async () => {
+      mockAxios.onGet('/api/forbidden').reply(403, { error: 'Forbidden' });
+
+      await expect(makeRequestWithRetry('GET', '/api/forbidden', {
+        retries: 3,
+        backoffFactor: 0.1
+      })).rejects.toThrow();
+
+      expect(mockAxios.history.get.length).toBe(1);
+    });
+
+    it('should not retry on 404 Not Found', async () => {
+      mockAxios.onGet('/api/not-found').reply(404, { error: 'Not Found' });
+
+      await expect(makeRequestWithRetry('GET', '/api/not-found', {
+        retries: 3,
+        backoffFactor: 0.1
+      })).rejects.toThrow();
+
+      expect(mockAxios.history.get.length).toBe(1);
+    });
+
+    it('should not retry on 409 Conflict', async () => {
+      mockAxios.onPost('/api/conflict').reply(409, { error: 'Conflict' });
+
+      await expect(makeRequestWithRetry('POST', '/api/conflict', {
+        retries: 3,
+        backoffFactor: 0.1
+      })).rejects.toThrow();
+
+      expect(mockAxios.history.post.length).toBe(1);
+    });
+  });
+
+  describe('idempotent methods', () => {
+    it('should NOT retry GET method on client errors (403)', async () => {
+      mockAxios.onGet('/api/forbidden-get').reply(403, { error: 'Forbidden' });
+
+      await expect(makeRequestWithRetry('GET', '/api/forbidden-get', {
+        retries: 3,
+        backoffFactor: 0.1
+      })).rejects.toThrow();
+
+      expect(mockAxios.history.get.length).toBe(1); // Only 1 attempt
+    });
+
+    it('should not retry POST method on non-retryable status codes', async () => {
+      mockAxios.onPost('/api/forbidden-post').reply(403, { error: 'Forbidden' });
+
+      await expect(makeRequestWithRetry('POST', '/api/forbidden-post', {
+        retries: 3,
+        backoffFactor: 0.1
+      })).rejects.toThrow();
+
+      expect(mockAxios.history.post.length).toBe(1);
+    });
+
+    it('should not retry PUT method on non-retryable status codes', async () => {
+      mockAxios.onPut('/api/forbidden-put').reply(403, { error: 'Forbidden' });
+
+      await expect(makeRequestWithRetry('PUT', '/api/forbidden-put', {
+        retries: 3,
+        backoffFactor: 0.1
+      })).rejects.toThrow();
+
+      expect(mockAxios.history.put.length).toBe(1);
+    });
+  });
+
+  describe('retry configuration options', () => {
+    it('should respect custom retry count', async () => {
+      mockAxios.onGet('/api/always-fail').reply(500);
+
+      await expect(makeRequestWithRetry('GET', '/api/always-fail', {
+        retries: 2,
+        backoffFactor: 0.1
+      })).rejects.toThrow();
+
+      // Initial attempt + 2 retries = 3 total requests
+      expect(mockAxios.history.get.length).toBe(3);
+    });
+
+    it('should handle zero retries (no retry attempts)', async () => {
+      mockAxios.onGet('/api/fail-once').reply(500);
+
+      await expect(makeRequestWithRetry('GET', '/api/fail-once', {
+        retries: 0,
+        backoffFactor: 0.1
+      })).rejects.toThrow();
+
+      expect(mockAxios.history.get.length).toBe(1);
+    });
+
+    it('should use exponential backoff with custom backoff factor', async () => {
+      mockAxios.onGet('/api/backoff-test').reply(500);
+
+      const startTime = Date.now();
+      const promise = makeRequestWithRetry('GET', '/api/backoff-test', {
+        retries: 2,
+        backoffFactor: 0.5,
+        maxJitterMs: 0 // Disable jitter for predictable testing
+      });
+
+      await expect(promise).rejects.toThrow();
+      const duration = Date.now() - startTime;
+
+      // Expected delays: 500ms + 1000ms = 1500ms minimum (with backoffFactor 0.5: 250ms + 500ms = 750ms)
+      expect(duration).toBeGreaterThanOrEqual(750);
+      expect(mockAxios.history.get.length).toBe(3);
+    });
+
+    it('should add random jitter to delays', async () => {
+      mockAxios.onGet('/api/jitter-test').reply(500);
+
+      const delays = [];
+      for (let i = 0; i < 3; i++) {
+        const startTime = Date.now();
+        try {
+          await makeRequestWithRetry('GET', '/api/jitter-test', {
+            retries: 1,
+            backoffFactor: 0.1,
+            maxJitterMs: 500
+          });
+        } catch (error) {
+          const duration = Date.now() - startTime;
+          delays.push(duration);
+        }
+        mockAxios.resetHistory();
+        await new Promise(resolve => setTimeout(resolve, 100));
+      }
+
+      // Delays should vary due to jitter
+      const uniqueDelays = new Set(delays.map(d => Math.floor(d / 100) * 100));
+      expect(uniqueDelays.size).toBeGreaterThan(1);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should throw error after exhausting all retries', async () => {
+      mockAxios.onGet('/api/exhaust-retries').reply(500);
+
+      try {
+        await makeRequestWithRetry('GET', '/api/exhaust-retries', {
+          retries: 1,
+          backoffFactor: 0.1
+        });
+        expect(true).toBe(false);
+      } catch (error) {
+        expect(error).toBeDefined();
+        expect(error.response.status).toBe(500);
+        expect(mockAxios.history.get.length).toBe(2);
+      }
+    });
+
+    it('should preserve the original error object', async () => {
+      const errorResponse = {
+        error: 'Server Error',
+        code: 'ERR_500',
+        timestamp: new Date().toISOString()
+      };
+      mockAxios.onGet('/api/preserve-error').reply(500, errorResponse);
+
+      try {
+        await makeRequestWithRetry('GET', '/api/preserve-error', {
+          retries: 1,
+          backoffFactor: 0.1
+        });
+      } catch (error) {
+        expect(error.response.status).toBe(500);
+        expect(error.response.data).toEqual(errorResponse);
+        expect(error.config).toBeDefined();
+      }
+    });
+
+    it('should handle timeout errors correctly', async () => {
+      mockAxios.onGet('/api/timeout').timeout();
+
+      try {
+        await makeRequestWithRetry('GET', '/api/timeout', {
+          retries: 1,
+          backoffFactor: 0.1
+        });
+      } catch (error) {
+        expect(error.code).toBe('ECONNABORTED');
+        expect(mockAxios.history.get.length).toBe(2);
+      }
+    });
+
+    it('should handle connection refused errors', async () => {
+      mockAxios.onGet('/api/connection-refused').networkError();
+
+      try {
+        await makeRequestWithRetry('GET', '/api/connection-refused', {
+          retries: 1,
+          backoffFactor: 0.1
+        });
+      } catch (error) {
+        expect(error.message).toBeDefined();
+        expect(mockAxios.history.get.length).toBe(2);
+      }
+    });
+  });
+
+  describe('logging behavior', () => {
+    it('should log successful request attempts', async () => {
+      mockAxios.onGet('/api/log-success').reply(200, { data: 'test' });
+
+      await makeRequestWithRetry('GET', '/api/log-success', { retries: 0 });
+
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringMatching(/\[Attempt 1\/1\] Request to GET \/api\/log-success succeeded in \d+ms/)
+      );
+    });
+
+    it('should log retry attempts', async () => {
+      mockAxios
+        .onGet('/api/log-retry')
+        .replyOnce(500)
+        .onGet('/api/log-retry')
+        .replyOnce(200);
+
+      await makeRequestWithRetry('GET', '/api/log-retry', {
+        retries: 1,
+        backoffFactor: 0.1
+      });
+
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining('Retry Attempt 2/2')
+      );
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining('Retrying in')
+      );
+    });
+
+    it('should log when no more retries are available', async () => {
+      mockAxios.onGet('/api/no-more-retries').reply(500);
+
+      try {
+        await makeRequestWithRetry('GET', '/api/no-more-retries', {
+          retries: 1,
+          backoffFactor: 0.1
+        });
+      } catch (error) {
+        expect(console.log).toHaveBeenCalledWith(
+          expect.stringContaining('No more retries')
+        );
+      }
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty response data', async () => {
+      mockAxios.onGet('/api/empty').reply(204, null);
+
+      const response = await makeRequestWithRetry('GET', '/api/empty', { retries: 0 });
+
+      expect(response.status).toBe(204);
+      expect(response.data).toBeNull();
+    });
+
+    it('should handle large response payloads', async () => {
+      const largeData = { items: Array(1000).fill({ id: 1, name: 'Test' }) };
+      mockAxios.onGet('/api/large').reply(200, largeData);
+
+      const response = await makeRequestWithRetry('GET', '/api/large', { retries: 0 });
+
+      expect(response.data.items.length).toBe(1000);
+    });
+
+    it('should handle special characters in URLs', async () => {
+      const specialUrl = '/api/users?filter=name:John%20Doe&tags=javascript,nodejs';
+      mockAxios.onGet(specialUrl).reply(200, {});
+
+      await makeRequestWithRetry('GET', specialUrl, { retries: 0 });
+
+      expect(mockAxios.history.get[0].url).toBe(specialUrl);
+    });
+
+    it('should handle concurrent requests independently', async () => {
+      mockAxios
+        .onGet('/api/request1')
+        .replyOnce(500)
+        .onGet('/api/request1')
+        .replyOnce(200, { id: 1 })
+        .onGet('/api/request2')
+        .replyOnce(500)
+        .onGet('/api/request2')
+        .replyOnce(200, { id: 2 });
+
+      const [response1, response2] = await Promise.all([
+        makeRequestWithRetry('GET', '/api/request1', { retries: 1, backoffFactor: 0.1 }),
+        makeRequestWithRetry('GET', '/api/request2', { retries: 1, backoffFactor: 0.1 })
+      ]);
+
+      expect(response1.data).toEqual({ id: 1 });
+      expect(response2.data).toEqual({ id: 2 });
+      expect(mockAxios.history.get.length).toBe(4);
+    });
+  });
+});

--- a/tests/network.test.js
+++ b/tests/network.test.js
@@ -465,6 +465,13 @@ describe('axiosRequestWithRetry', () => {
     });
 
     it('should add random jitter to delays', async () => {
+      // Mock Math.random to return predictable values
+      const randomSpy = jest
+        .spyOn(Math, 'random')
+        .mockReturnValueOnce(0.1)  // e.g., 50ms jitter (500 * 0.1)
+        .mockReturnValueOnce(0.5)  // 250ms jitter
+        .mockReturnValueOnce(0.9); // 450ms jitter
+
       mockAxios.onGet('/api/jitter-test').reply(500);
 
       const delays = [];
@@ -484,9 +491,14 @@ describe('axiosRequestWithRetry', () => {
         await new Promise(resolve => setTimeout(resolve, 100));
       }
 
-      // Delays should vary due to jitter. Note: If randomness produces identical values by chance, this will fail.
-      const uniqueDelays = new Set(delays.map(d => Math.floor(d / 100) * 100));
-      expect(uniqueDelays.size).toBeGreaterThan(1);
+      // Assert that random was called exactly 3 times
+      expect(randomSpy).toHaveBeenCalledTimes(3);
+
+      // Assert delays are unique and match expected jitter (roughly)
+      expect(delays).toHaveLength(3);
+      expect(new Set(delays).size).toBe(3); // all unique
+
+      randomSpy.mockRestore();
     });
   });
 

--- a/tests/network.test.js
+++ b/tests/network.test.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
-import { makeRequestWithRetry, axiosGetWithRetry, axiosPostWithRetry } from '../src/util/network.js';
+import { axiosRequestWithRetry, axiosGetWithRetry, axiosPostWithRetry } from '../src/util/network.js';
 
 // Mock console.log to avoid cluttering test output
 global.console = {
@@ -11,7 +11,7 @@ global.console = {
   debug: jest.fn()
 };
 
-describe('makeRequestWithRetry', () => {
+describe('axiosRequestWithRetry', () => {
   let mockAxios;
 
   beforeEach(() => {
@@ -29,7 +29,7 @@ describe('makeRequestWithRetry', () => {
       const mockData = { id: 1, name: 'Test User' };
       mockAxios.onGet('/api/users/1').reply(200, mockData);
 
-      const response = await makeRequestWithRetry('GET', '/api/users/1', { retries: 0 });
+      const response = await axiosRequestWithRetry('GET', '/api/users/1', { retries: 0 });
 
       expect(response.status).toBe(200);
       expect(response.data).toEqual(mockData);
@@ -39,7 +39,7 @@ describe('makeRequestWithRetry', () => {
     it('should handle query parameters correctly', async () => {
       mockAxios.onGet('/api/users').reply(200, { users: [] });
 
-      await makeRequestWithRetry('GET', '/api/users', {
+      await axiosRequestWithRetry('GET', '/api/users', {
         params: { page: 1, limit: 10, sort: 'desc' },
         retries: 0
       });
@@ -54,7 +54,7 @@ describe('makeRequestWithRetry', () => {
     it('should handle request headers correctly', async () => {
       mockAxios.onGet('/api/secure').reply(200, {});
 
-      await makeRequestWithRetry('GET', '/api/secure', {
+      await axiosRequestWithRetry('GET', '/api/secure', {
         headers: {
           Authorization: 'Bearer token123',
           'X-Custom-Header': 'custom-value'
@@ -70,7 +70,7 @@ describe('makeRequestWithRetry', () => {
       const postData = { name: 'John Doe', email: 'john@example.com', age: 30 };
       mockAxios.onPost('/api/users').reply(201, { id: 1, ...postData });
 
-      const response = await makeRequestWithRetry('POST', '/api/users', {
+      const response = await axiosRequestWithRetry('POST', '/api/users', {
         data: postData,
         headers: { 'Content-Type': 'application/json' },
         retries: 0
@@ -85,7 +85,7 @@ describe('makeRequestWithRetry', () => {
       const updateData = { name: 'Jane Doe' };
       mockAxios.onPut('/api/users/1').reply(200, { id: 1, ...updateData });
 
-      const response = await makeRequestWithRetry('PUT', '/api/users/1', {
+      const response = await axiosRequestWithRetry('PUT', '/api/users/1', {
         data: updateData,
         retries: 0
       });
@@ -97,7 +97,7 @@ describe('makeRequestWithRetry', () => {
     it('should handle DELETE requests', async () => {
       mockAxios.onDelete('/api/users/1').reply(204, null);
 
-      const response = await makeRequestWithRetry('DELETE', '/api/users/1', { retries: 0 });
+      const response = await axiosRequestWithRetry('DELETE', '/api/users/1', { retries: 0 });
 
       expect(response.status).toBe(204);
       expect(mockAxios.history.delete.length).toBe(1);
@@ -112,7 +112,7 @@ describe('makeRequestWithRetry', () => {
         .onGet('/api/unstable')
         .replyOnce(200, { success: true, data: 'Recovered data' });
 
-      const response = await makeRequestWithRetry('GET', '/api/unstable', {
+      const response = await axiosRequestWithRetry('GET', '/api/unstable', {
         retries: 1,
         backoffFactor: 0.1
       });
@@ -132,7 +132,7 @@ describe('makeRequestWithRetry', () => {
         .onGet('/api/gateway')
         .replyOnce(200, { status: 'ok' });
 
-      const response = await makeRequestWithRetry('GET', '/api/gateway', {
+      const response = await axiosRequestWithRetry('GET', '/api/gateway', {
         retries: 1,
         backoffFactor: 0.1
       });
@@ -148,7 +148,7 @@ describe('makeRequestWithRetry', () => {
         .onGet('/api/service')
         .replyOnce(200, { healthy: true });
 
-      const response = await makeRequestWithRetry('GET', '/api/service', {
+      const response = await axiosRequestWithRetry('GET', '/api/service', {
         retries: 1,
         backoffFactor: 0.1
       });
@@ -164,7 +164,7 @@ describe('makeRequestWithRetry', () => {
         .onGet('/api/timeout')
         .replyOnce(200, { completed: true });
 
-      const response = await makeRequestWithRetry('GET', '/api/timeout', {
+      const response = await axiosRequestWithRetry('GET', '/api/timeout', {
         retries: 1,
         backoffFactor: 0.1
       });
@@ -180,7 +180,7 @@ describe('makeRequestWithRetry', () => {
         .onGet('/api/rate-limited')
         .replyOnce(200, { success: true });
 
-      const response = await makeRequestWithRetry('GET', '/api/rate-limited', {
+      const response = await axiosRequestWithRetry('GET', '/api/rate-limited', {
         retries: 1,
         backoffFactor: 0.1
       });
@@ -196,7 +196,7 @@ describe('makeRequestWithRetry', () => {
         .onGet('/api/network-error')
         .replyOnce(200, { recovered: true });
 
-      const response = await makeRequestWithRetry('GET', '/api/network-error', {
+      const response = await axiosRequestWithRetry('GET', '/api/network-error', {
         retries: 1,
         backoffFactor: 0.1
       });
@@ -216,7 +216,7 @@ describe('makeRequestWithRetry', () => {
         .onGet('/api/retry-multiple')
         .replyOnce(200, { finally: 'success' });
 
-      const response = await makeRequestWithRetry('GET', '/api/retry-multiple', {
+      const response = await axiosRequestWithRetry('GET', '/api/retry-multiple', {
         retries: 3,
         backoffFactor: 0.1
       });
@@ -230,7 +230,7 @@ describe('makeRequestWithRetry', () => {
     it('should not retry on 400 Bad Request', async () => {
       mockAxios.onGet('/api/bad-request').reply(400, { error: 'Bad Request' });
 
-      await expect(makeRequestWithRetry('GET', '/api/bad-request', {
+      await expect(axiosRequestWithRetry('GET', '/api/bad-request', {
         retries: 3,
         backoffFactor: 0.1
       })).rejects.toThrow();
@@ -241,7 +241,7 @@ describe('makeRequestWithRetry', () => {
     it('should not retry on 401 Unauthorized', async () => {
       mockAxios.onGet('/api/unauthorized').reply(401, { error: 'Unauthorized' });
 
-      await expect(makeRequestWithRetry('GET', '/api/unauthorized', {
+      await expect(axiosRequestWithRetry('GET', '/api/unauthorized', {
         retries: 3,
         backoffFactor: 0.1
       })).rejects.toThrow();
@@ -252,7 +252,7 @@ describe('makeRequestWithRetry', () => {
     it('should not retry on 403 Forbidden', async () => {
       mockAxios.onGet('/api/forbidden').reply(403, { error: 'Forbidden' });
 
-      await expect(makeRequestWithRetry('GET', '/api/forbidden', {
+      await expect(axiosRequestWithRetry('GET', '/api/forbidden', {
         retries: 3,
         backoffFactor: 0.1
       })).rejects.toThrow();
@@ -263,7 +263,7 @@ describe('makeRequestWithRetry', () => {
     it('should not retry on 404 Not Found', async () => {
       mockAxios.onGet('/api/not-found').reply(404, { error: 'Not Found' });
 
-      await expect(makeRequestWithRetry('GET', '/api/not-found', {
+      await expect(axiosRequestWithRetry('GET', '/api/not-found', {
         retries: 3,
         backoffFactor: 0.1
       })).rejects.toThrow();
@@ -274,7 +274,7 @@ describe('makeRequestWithRetry', () => {
     it('should not retry on 409 Conflict', async () => {
       mockAxios.onPost('/api/conflict').reply(409, { error: 'Conflict' });
 
-      await expect(makeRequestWithRetry('POST', '/api/conflict', {
+      await expect(axiosRequestWithRetry('POST', '/api/conflict', {
         retries: 3,
         backoffFactor: 0.1
       })).rejects.toThrow();
@@ -287,7 +287,7 @@ describe('makeRequestWithRetry', () => {
     it('should NOT retry GET method on client errors (403)', async () => {
       mockAxios.onGet('/api/forbidden-get').reply(403, { error: 'Forbidden' });
 
-      await expect(makeRequestWithRetry('GET', '/api/forbidden-get', {
+      await expect(axiosRequestWithRetry('GET', '/api/forbidden-get', {
         retries: 3,
         backoffFactor: 0.1
       })).rejects.toThrow();
@@ -298,7 +298,7 @@ describe('makeRequestWithRetry', () => {
     it('should not retry POST method on non-retryable status codes', async () => {
       mockAxios.onPost('/api/forbidden-post').reply(403, { error: 'Forbidden' });
 
-      await expect(makeRequestWithRetry('POST', '/api/forbidden-post', {
+      await expect(axiosRequestWithRetry('POST', '/api/forbidden-post', {
         retries: 3,
         backoffFactor: 0.1
       })).rejects.toThrow();
@@ -309,7 +309,7 @@ describe('makeRequestWithRetry', () => {
     it('should not retry PUT method on non-retryable status codes', async () => {
       mockAxios.onPut('/api/forbidden-put').reply(403, { error: 'Forbidden' });
 
-      await expect(makeRequestWithRetry('PUT', '/api/forbidden-put', {
+      await expect(axiosRequestWithRetry('PUT', '/api/forbidden-put', {
         retries: 3,
         backoffFactor: 0.1
       })).rejects.toThrow();
@@ -324,7 +324,7 @@ describe('makeRequestWithRetry', () => {
 
       const startTime = Date.now();
 
-      await expect(makeRequestWithRetry('GET', '/api/slow', {
+      await expect(axiosRequestWithRetry('GET', '/api/slow', {
         retries: 5,
         backoffFactor: 0.5,
         timeout: 1000
@@ -342,7 +342,7 @@ describe('makeRequestWithRetry', () => {
         .onGet('/api/recovers')
         .replyOnce(200, { success: true });
 
-      const response = await makeRequestWithRetry('GET', '/api/recovers', {
+      const response = await axiosRequestWithRetry('GET', '/api/recovers', {
         retries: 3,
         backoffFactor: 0.1,
         timeout: 5000
@@ -358,7 +358,7 @@ describe('makeRequestWithRetry', () => {
       const startTime = Date.now();
 
       await expect(
-        makeRequestWithRetry('GET', '/api/long-delay', {
+        axiosRequestWithRetry('GET', '/api/long-delay', {
           retries: 3,
           backoffFactor: 2,
           maxJitterMs: 0,
@@ -377,7 +377,7 @@ describe('makeRequestWithRetry', () => {
       mockAxios.onGet('/api/slow-response').timeout();
 
       await expect(
-        makeRequestWithRetry('GET', '/api/slow-response', {
+        axiosRequestWithRetry('GET', '/api/slow-response', {
           retries: 1,
           backoffFactor: 0.1,
           timeout: 500
@@ -395,7 +395,7 @@ describe('makeRequestWithRetry', () => {
         return [500, { error: 'Server Error' }];
       });
 
-      await expect(makeRequestWithRetry('GET', '/api/retry-after-timeout', {
+      await expect(axiosRequestWithRetry('GET', '/api/retry-after-timeout', {
         retries: 10,
         backoffFactor: 0.5,
         timeout: 800
@@ -412,7 +412,7 @@ describe('makeRequestWithRetry', () => {
         .onGet('/api/no-timeout')
         .replyOnce(200, { success: true });
 
-      const response = await makeRequestWithRetry('GET', '/api/no-timeout', {
+      const response = await axiosRequestWithRetry('GET', '/api/no-timeout', {
         retries: 1,
         backoffFactor: 0.1
       });
@@ -426,7 +426,7 @@ describe('makeRequestWithRetry', () => {
     it('should respect custom retry count', async () => {
       mockAxios.onGet('/api/always-fail').reply(500);
 
-      await expect(makeRequestWithRetry('GET', '/api/always-fail', {
+      await expect(axiosRequestWithRetry('GET', '/api/always-fail', {
         retries: 2,
         backoffFactor: 0.1
       })).rejects.toThrow();
@@ -438,7 +438,7 @@ describe('makeRequestWithRetry', () => {
     it('should handle zero retries (no retry attempts)', async () => {
       mockAxios.onGet('/api/fail-once').reply(500);
 
-      await expect(makeRequestWithRetry('GET', '/api/fail-once', {
+      await expect(axiosRequestWithRetry('GET', '/api/fail-once', {
         retries: 0,
         backoffFactor: 0.1
       })).rejects.toThrow();
@@ -450,7 +450,7 @@ describe('makeRequestWithRetry', () => {
       mockAxios.onGet('/api/backoff-test').reply(500);
 
       const startTime = Date.now();
-      const promise = makeRequestWithRetry('GET', '/api/backoff-test', {
+      const promise = axiosRequestWithRetry('GET', '/api/backoff-test', {
         retries: 2,
         backoffFactor: 0.5,
         maxJitterMs: 0 // Disable jitter for predictable testing
@@ -471,7 +471,7 @@ describe('makeRequestWithRetry', () => {
       for (let i = 0; i < 3; i++) {
         const startTime = Date.now();
         try {
-          await makeRequestWithRetry('GET', '/api/jitter-test', {
+          await axiosRequestWithRetry('GET', '/api/jitter-test', {
             retries: 1,
             backoffFactor: 0.1,
             maxJitterMs: 500
@@ -495,7 +495,7 @@ describe('makeRequestWithRetry', () => {
       mockAxios.onGet('/api/exhaust-retries').reply(500);
 
       try {
-        await makeRequestWithRetry('GET', '/api/exhaust-retries', {
+        await axiosRequestWithRetry('GET', '/api/exhaust-retries', {
           retries: 1,
           backoffFactor: 0.1
         });
@@ -516,7 +516,7 @@ describe('makeRequestWithRetry', () => {
       mockAxios.onGet('/api/preserve-error').reply(500, errorResponse);
 
       try {
-        await makeRequestWithRetry('GET', '/api/preserve-error', {
+        await axiosRequestWithRetry('GET', '/api/preserve-error', {
           retries: 1,
           backoffFactor: 0.1
         });
@@ -532,7 +532,7 @@ describe('makeRequestWithRetry', () => {
       mockAxios.onGet('/api/timeout').timeout();
 
       try {
-        await makeRequestWithRetry('GET', '/api/timeout', {
+        await axiosRequestWithRetry('GET', '/api/timeout', {
           retries: 1,
           backoffFactor: 0.1
         });
@@ -547,7 +547,7 @@ describe('makeRequestWithRetry', () => {
       mockAxios.onGet('/api/timeout').reply(408);
 
       try {
-        await makeRequestWithRetry('GET', '/api/timeout', {
+        await axiosRequestWithRetry('GET', '/api/timeout', {
           retries: 1,
           backoffFactor: 0.1
         });
@@ -561,7 +561,7 @@ describe('makeRequestWithRetry', () => {
       mockAxios.onGet('/api/connection-refused').networkError();
 
       try {
-        await makeRequestWithRetry('GET', '/api/connection-refused', {
+        await axiosRequestWithRetry('GET', '/api/connection-refused', {
           retries: 1,
           backoffFactor: 0.1
         });
@@ -576,7 +576,7 @@ describe('makeRequestWithRetry', () => {
     it('should log successful request attempts', async () => {
       mockAxios.onGet('/api/log-success').reply(200, { data: 'test' });
 
-      await makeRequestWithRetry('GET', '/api/log-success', { retries: 0 });
+      await axiosRequestWithRetry('GET', '/api/log-success', { retries: 0 });
 
       expect(console.log).toHaveBeenCalledWith(
         expect.stringMatching(/\[Attempt 1\/1\] Request to GET \/api\/log-success succeeded in \d+ms/)
@@ -590,7 +590,7 @@ describe('makeRequestWithRetry', () => {
         .onGet('/api/log-retry')
         .replyOnce(200);
 
-      await makeRequestWithRetry('GET', '/api/log-retry', {
+      await axiosRequestWithRetry('GET', '/api/log-retry', {
         retries: 1,
         backoffFactor: 0.1
       });
@@ -607,7 +607,7 @@ describe('makeRequestWithRetry', () => {
       mockAxios.onGet('/api/no-more-retries').reply(500);
 
       try {
-        await makeRequestWithRetry('GET', '/api/no-more-retries', {
+        await axiosRequestWithRetry('GET', '/api/no-more-retries', {
           retries: 1,
           backoffFactor: 0.1
         });
@@ -623,7 +623,7 @@ describe('makeRequestWithRetry', () => {
     it('should handle empty response data', async () => {
       mockAxios.onGet('/api/empty').reply(204, null);
 
-      const response = await makeRequestWithRetry('GET', '/api/empty', { retries: 0 });
+      const response = await axiosRequestWithRetry('GET', '/api/empty', { retries: 0 });
 
       expect(response.status).toBe(204);
       expect(response.data).toBeNull();
@@ -633,7 +633,7 @@ describe('makeRequestWithRetry', () => {
       const largeData = { items: Array(1000).fill({ id: 1, name: 'Test' }) };
       mockAxios.onGet('/api/large').reply(200, largeData);
 
-      const response = await makeRequestWithRetry('GET', '/api/large', { retries: 0 });
+      const response = await axiosRequestWithRetry('GET', '/api/large', { retries: 0 });
 
       expect(response.data.items.length).toBe(1000);
     });
@@ -642,7 +642,7 @@ describe('makeRequestWithRetry', () => {
       const specialUrl = '/api/users?filter=name:John%20Doe&tags=javascript,nodejs';
       mockAxios.onGet(specialUrl).reply(200, {});
 
-      await makeRequestWithRetry('GET', specialUrl, { retries: 0 });
+      await axiosRequestWithRetry('GET', specialUrl, { retries: 0 });
 
       expect(mockAxios.history.get[0].url).toBe(specialUrl);
     });
@@ -659,8 +659,8 @@ describe('makeRequestWithRetry', () => {
         .replyOnce(200, { id: 2 });
 
       const [response1, response2] = await Promise.all([
-        makeRequestWithRetry('GET', '/api/request1', { retries: 1, backoffFactor: 0.1 }),
-        makeRequestWithRetry('GET', '/api/request2', { retries: 1, backoffFactor: 0.1 })
+        axiosRequestWithRetry('GET', '/api/request1', { retries: 1, backoffFactor: 0.1 }),
+        axiosRequestWithRetry('GET', '/api/request2', { retries: 1, backoffFactor: 0.1 })
       ]);
 
       expect(response1.data).toEqual({ id: 1 });
@@ -671,10 +671,10 @@ describe('makeRequestWithRetry', () => {
 
   // Verify the wrappers work as expected
   describe('wrapper convenience functions', () => {
-    it('axiosGetWithRetry should work like makeRequestWithRetry with GET', async () => {
+    it('axiosGetWithRetry should work like axiosRequestWithRetry with GET', async () => {
       mockAxios.onGet('/api/test').reply(200, { data: 'test' });
 
-      const result1 = await makeRequestWithRetry('GET', '/api/test');
+      const result1 = await axiosRequestWithRetry('GET', '/api/test');
       const result2 = await axiosGetWithRetry('/api/test');
 
       expect(result1.data).toEqual(result2.data);
@@ -700,6 +700,150 @@ describe('makeRequestWithRetry', () => {
 
       expect(response.data).toEqual({ ok: true });
       expect(mockAxios.history.get.length).toBe(2);
+    });
+  });
+
+  describe('wrapper functions with various parameter combinations', () => {
+    it('axiosGetWithRetry: no config or retry', async () => {
+      mockAxios.onGet('/api/get-no-config').reply(200, { data: 'test' });
+
+      const response = await axiosGetWithRetry('/api/get-no-config');
+
+      expect(response.status).toBe(200);
+      expect(response.data).toEqual({ data: 'test' });
+      expect(mockAxios.history.get.length).toBe(1);
+    });
+
+    it('axiosGetWithRetry: config and retry settings', async () => {
+      mockAxios
+        .onGet('/api/get-with-config')
+        .replyOnce(500)
+        .onGet('/api/get-with-config')
+        .replyOnce(200, { success: true });
+
+      const response = await axiosGetWithRetry(
+        '/api/get-with-config',
+        {
+          headers: { 'X-Custom-Header': 'custom-value' },
+          params: { page: 1, limit: 10 }
+        },
+        {
+          retries: 1,
+          backoffFactor: 0.1
+        }
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.data).toEqual({ success: true });
+      expect(mockAxios.history.get.length).toBe(2);
+      // Verify headers and params were passed correctly
+      expect(mockAxios.history.get[0].headers['X-Custom-Header']).toBe('custom-value');
+      expect(mockAxios.history.get[0].params).toEqual({ page: 1, limit: 10 });
+    });
+
+    it('axiosPostWithRetry: data and config and retry', async () => {
+      const postData = { name: 'John Doe', email: 'john@example.com' };
+      mockAxios
+        .onPost('/api/post-with-all')
+        .replyOnce(500)
+        .onPost('/api/post-with-all')
+        .replyOnce(201, { id: 1, ...postData });
+
+      const response = await axiosPostWithRetry(
+        '/api/post-with-all',
+        postData,
+        {
+          headers: { 'Content-Type': 'application/json', 'X-API-Key': 'test-key' },
+          params: { validate: true }
+        },
+        {
+          retries: 1,
+          backoffFactor: 0.1,
+          maxJitterMs: 0
+        }
+      );
+
+      expect(response.status).toBe(201);
+      expect(response.data).toHaveProperty('id', 1);
+      expect(JSON.parse(mockAxios.history.post[0].data)).toEqual(postData);
+      expect(mockAxios.history.post[0].headers['X-API-Key']).toBe('test-key');
+      expect(mockAxios.history.post[0].params).toEqual({ validate: true });
+      expect(mockAxios.history.post.length).toBe(2);
+    });
+
+    it('axiosPostWithRetry: empty data, config, empty retry', async () => {
+      mockAxios.onPost('/api/post-empty-data').reply(200, { received: null });
+
+      const response = await axiosPostWithRetry(
+        '/api/post-empty-data',
+        {},
+        { headers: { 'Content-Type': 'application/json' } },
+        {}
+      );
+
+      expect(response.status).toBe(200);
+      expect(JSON.parse(mockAxios.history.post[0].data)).toEqual({});
+      expect(mockAxios.history.post.length).toBe(1);
+    });
+
+    it('axiosPostWithRetry: empty data, config, retry', async () => {
+      mockAxios
+        .onPost('/api/post-empty-data-retry')
+        .replyOnce(503)
+        .onPost('/api/post-empty-data-retry')
+        .replyOnce(200, { status: 'recovered' });
+
+      const response = await axiosPostWithRetry(
+        '/api/post-empty-data-retry',
+        {},
+        { headers: { 'X-Test': 'value' }, params: { retry: true } },
+        { retries: 1, backoffFactor: 0.1 }
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.data).toEqual({ status: 'recovered' });
+      expect(JSON.parse(mockAxios.history.post[0].data)).toEqual({});
+      expect(mockAxios.history.post[0].headers['X-Test']).toBe('value');
+      expect(mockAxios.history.post[0].params).toEqual({ retry: true });
+      expect(mockAxios.history.post.length).toBe(2);
+    });
+
+    it('axiosPostWithRetry: data, config, retry', async () => {
+      const postData = { action: 'update', value: 42 };
+      mockAxios
+        .onPost('/api/post-all-three')
+        .replyOnce(502)
+        .onPost('/api/post-all-three')
+        .replyOnce(200, { processed: true, value: 42 });
+
+      const response = await axiosPostWithRetry(
+        '/api/post-all-three',
+        postData,
+        {
+          headers: { 'Authorization': 'Bearer token123', 'X-Request-ID': 'req-123' },
+          params: { format: 'json', pretty: true },
+          timeout: 5000
+        },
+        {
+          retries: 2,
+          backoffFactor: 0.2,
+          maxJitterMs: 100,
+          timeout: 10000
+        }
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.data).toEqual({ processed: true, value: 42 });
+      expect(JSON.parse(mockAxios.history.post[0].data)).toEqual(postData);
+      expect(mockAxios.history.post[0].headers['Authorization']).toBe('Bearer token123');
+      expect(mockAxios.history.post[0].headers['X-Request-ID']).toBe('req-123');
+      expect(mockAxios.history.post[0].params).toEqual({ format: 'json', pretty: true });
+      expect(mockAxios.history.post.length).toBe(2);
+
+      // Verify retry happened
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining('Retrying')
+      );
     });
   });
 });

--- a/tests/network.test.js
+++ b/tests/network.test.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
-import { makeRequestWithRetry } from '../src/util/network.js';
+import { makeRequestWithRetry, axiosGetWithRetry, axiosPostWithRetry } from '../src/util/network.js';
 
 // Mock console.log to avoid cluttering test output
 global.console = {
@@ -666,6 +666,40 @@ describe('makeRequestWithRetry', () => {
       expect(response1.data).toEqual({ id: 1 });
       expect(response2.data).toEqual({ id: 2 });
       expect(mockAxios.history.get.length).toBe(4);
+    });
+  });
+
+  // Verify the wrappers work as expected
+  describe('wrapper convenience functions', () => {
+    it('axiosGetWithRetry should work like makeRequestWithRetry with GET', async () => {
+      mockAxios.onGet('/api/test').reply(200, { data: 'test' });
+
+      const result1 = await makeRequestWithRetry('GET', '/api/test');
+      const result2 = await axiosGetWithRetry('/api/test');
+
+      expect(result1.data).toEqual(result2.data);
+    });
+
+    it('axiosPostWithRetry should pass data correctly', async () => {
+      const postData = { name: 'test' };
+      mockAxios.onPost('/api/test').reply(200, { received: postData });
+
+      const response = await axiosPostWithRetry('/api/test', postData);
+
+      expect(JSON.parse(mockAxios.history.post[0].data)).toEqual(postData);
+    });
+
+    it('should preserve retry behavior', async () => {
+      mockAxios
+        .onGet('/api/retry')
+        .replyOnce(500)
+        .onGet('/api/retry')
+        .replyOnce(200, { ok: true });
+
+      const response = await axiosGetWithRetry('/api/retry', {}, { retries: 1, backoffFactor: 0.1 });
+
+      expect(response.data).toEqual({ ok: true });
+      expect(mockAxios.history.get.length).toBe(2);
     });
   });
 });


### PR DESCRIPTION
Fixes #479

Tests created for new makeRequestWithRetry function are passing locally. To run all tests, use:

 ```
npm test
```

May need to install `devDependencies`, as jest is a new library.
