### PR TITLE
Fix advanced settings save flow on mobile

### DIFF
--- a/src/components/pages/Neutral.vue
+++ b/src/components/pages/Neutral.vue
@@ -169,150 +169,152 @@
                         </v-btn>
                       </v-card-actions>
 
-                      <v-card-title class="justify-center data-title">
-                        <span class="mr-2">Scaling setup</span>
-                        <v-tooltip bottom="" max-width="500px">
-                          <template v-slot:activator="{ on }">
-                            <v-icon v-on="on"> mdi-help-circle-outline </v-icon>
-                          </template>
-                          OpenCap uses data from the neutral pose to scale the musculoskeletal model to the anthropometry of the subject.
-                          By default, OpenCap assumes that the subject is standing with an upright posture and the feet pointing forward (i.e., straight back and no bending or rotation at the hips, knees, or ankles) as shown in the example neutral pose. These assumptions are modeled in the OpenSim scaling setup.
-                          If the subject cannot adopt this pose, you can select the "Any pose" scaling setup, which does not assume any specific posture but still requires all body segments to be visible by at least two cameras.
-                          We recommend using the default scaling setup unless the subject cannot adopt the upright standing neutral pose.
-                        </v-tooltip>
-                      </v-card-title>
-                      <v-card-text class="d-flex flex-column align-center checkbox-wrapper">
-                        <v-select
-                            v-model="scaling_setup"
-                            label="Select scaling setup"
-                            :items="scaling_setups"
-                            item-text="text"
-                            item-value="value"
-                          />
-                      </v-card-text>
+                      <div class="advanced-settings-body">
+                        <v-card-title class="justify-center data-title">
+                          <span class="mr-2">Scaling setup</span>
+                          <v-tooltip bottom="" max-width="500px">
+                            <template v-slot:activator="{ on }">
+                              <v-icon v-on="on"> mdi-help-circle-outline </v-icon>
+                            </template>
+                            OpenCap uses data from the neutral pose to scale the musculoskeletal model to the anthropometry of the subject.
+                            By default, OpenCap assumes that the subject is standing with an upright posture and the feet pointing forward (i.e., straight back and no bending or rotation at the hips, knees, or ankles) as shown in the example neutral pose. These assumptions are modeled in the OpenSim scaling setup.
+                            If the subject cannot adopt this pose, you can select the "Any pose" scaling setup, which does not assume any specific posture but still requires all body segments to be visible by at least two cameras.
+                            We recommend using the default scaling setup unless the subject cannot adopt the upright standing neutral pose.
+                          </v-tooltip>
+                        </v-card-title>
+                        <v-card-text class="d-flex flex-column align-center checkbox-wrapper">
+                          <v-select
+                              v-model="scaling_setup"
+                              label="Select scaling setup"
+                              :items="scaling_setups"
+                              item-text="text"
+                              item-value="value"
+                            />
+                        </v-card-text>
 
-                      <v-card-title class="justify-center data-title">
-                        <span class="mr-2">Human pose estimation model</span>
-                        <v-tooltip bottom="" max-width="500px">
-                          <template v-slot:activator="{ on }">
-                            <v-icon v-on="on"> mdi-help-circle-outline </v-icon>
-                          </template>
-                          OpenCap supports two human pose estimation models: OpenPose and HRNet. We recommend using OpenPose for computation speed, but both models provide similar accuracy.
-                          OpenPose is restricted to academic or non-profit organization non-commercial research use (consult the license at https://github.com/CMU-Perceptual-Computing-Lab/openpose/blob/master/LICENSE).
-                          HRNet, as implemented by Open-MMLab, has a permissive Apache 2.0 license (consult the license at https://github.com/open-mmlab/mmpose/blob/master/LICENSE).
-                          Please ensure that you have the rights to use the model you select. The OpenCap authors deny any responsibility regarding license infringement.
-                        </v-tooltip>
-                      </v-card-title>
-                      <v-card-text class="d-flex flex-column align-center checkbox-wrapper">
-                        <v-select
-                            v-model="pose_model"
-                            label="Select human pose estimation model"
-                            :items="pose_models"
-                            item-text="text"
-                            item-value="value"
-                          />
-                      </v-card-text>
+                        <v-card-title class="justify-center data-title">
+                          <span class="mr-2">Human pose estimation model</span>
+                          <v-tooltip bottom="" max-width="500px">
+                            <template v-slot:activator="{ on }">
+                              <v-icon v-on="on"> mdi-help-circle-outline </v-icon>
+                            </template>
+                            OpenCap supports two human pose estimation models: OpenPose and HRNet. We recommend using OpenPose for computation speed, but both models provide similar accuracy.
+                            OpenPose is restricted to academic or non-profit organization non-commercial research use (consult the license at https://github.com/CMU-Perceptual-Computing-Lab/openpose/blob/master/LICENSE).
+                            HRNet, as implemented by Open-MMLab, has a permissive Apache 2.0 license (consult the license at https://github.com/open-mmlab/mmpose/blob/master/LICENSE).
+                            Please ensure that you have the rights to use the model you select. The OpenCap authors deny any responsibility regarding license infringement.
+                          </v-tooltip>
+                        </v-card-title>
+                        <v-card-text class="d-flex flex-column align-center checkbox-wrapper">
+                          <v-select
+                              v-model="pose_model"
+                              label="Select human pose estimation model"
+                              :items="pose_models"
+                              item-text="text"
+                              item-value="value"
+                            />
+                        </v-card-text>
   
-                      <v-card-title class="justify-center data-title">
-                        <span class="mr-2">Framerate</span>
-                        <v-tooltip bottom="" max-width="500px">
-                          <template v-slot:activator="{ on }">
-                            <v-icon v-on="on"> mdi-help-circle-outline </v-icon>
-                          </template>
-                          The framerate determines the number of frames per second at which the videos are recorded. Higher framerates provide more temporal resolution but reduce the maximum recording time.
-                        </v-tooltip>
-                      </v-card-title>
-                      <v-card-text class="d-flex flex-column align-center checkbox-wrapper">
-                        <v-select
-                            v-model="framerate"
-                            label="Select framerate"
-                            :items="framerates_available"
-                            item-text="text"
-                            item-value="value"
-                            @change="updateFrequency"
-                          />
-                      </v-card-text>
+                        <v-card-title class="justify-center data-title">
+                          <span class="mr-2">Framerate</span>
+                          <v-tooltip bottom="" max-width="500px">
+                            <template v-slot:activator="{ on }">
+                              <v-icon v-on="on"> mdi-help-circle-outline </v-icon>
+                            </template>
+                            The framerate determines the number of frames per second at which the videos are recorded. Higher framerates provide more temporal resolution but reduce the maximum recording time.
+                          </v-tooltip>
+                        </v-card-title>
+                        <v-card-text class="d-flex flex-column align-center checkbox-wrapper">
+                          <v-select
+                              v-model="framerate"
+                              label="Select framerate"
+                              :items="framerates_available"
+                              item-text="text"
+                              item-value="value"
+                              @change="updateFrequency"
+                            />
+                        </v-card-text>
 
-                      <v-card-title class="justify-center data-title">
-                        <span class="mr-2">Musculoskeletal model</span>
-                        <v-tooltip bottom="" max-width="500px">
-                          <template v-slot:activator="{ on }">
-                            <v-icon v-on="on"> mdi-help-circle-outline </v-icon>
-                          </template>
-                          Full body model: Musculoskeletal model with 33 degrees of freedom from Lai et al. 2017 (https://pubmed.ncbi.nlm.nih.gov/28900782/) with modified hip abductor muscle paths from Uhlrich et al. 2022 (https://pubmed.ncbi.nlm.nih.gov/35798755/). Recommended for primarily lower extremity tasks (e.g., gait).
-                          <br><br>
-                          Full body model with ISB shoulder: Incorporates a 6 degree-of-freedom shoulder complex joint. It incorporates a scapulothoracic body with 3 translational degrees of freedom relative to the torso. The glenohumoral joint uses the Y-X-Y rotation sequence (elevation plane, elevation, rotation) recommended by the ISB (https://pubmed.ncbi.nlm.nih.gov/15844264/). Recommended for upper extremity tasks (e.g., pitching).
-                        </v-tooltip>
-                      </v-card-title>
-                      <v-card-text class="d-flex flex-column align-center checkbox-wrapper">
-                        <v-select
-                            v-model="openSimModel"
-                            label="Select musculoskeletal model"
-                            :items="openSimModels"
-                            item-text="text"
-                            item-value="value"
-                          />
-                      </v-card-text>
+                        <v-card-title class="justify-center data-title">
+                          <span class="mr-2">Musculoskeletal model</span>
+                          <v-tooltip bottom="" max-width="500px">
+                            <template v-slot:activator="{ on }">
+                              <v-icon v-on="on"> mdi-help-circle-outline </v-icon>
+                            </template>
+                            Full body model: Musculoskeletal model with 33 degrees of freedom from Lai et al. 2017 (https://pubmed.ncbi.nlm.nih.gov/28900782/) with modified hip abductor muscle paths from Uhlrich et al. 2022 (https://pubmed.ncbi.nlm.nih.gov/35798755/). Recommended for primarily lower extremity tasks (e.g., gait).
+                            <br><br>
+                            Full body model with ISB shoulder: Incorporates a 6 degree-of-freedom shoulder complex joint. It incorporates a scapulothoracic body with 3 translational degrees of freedom relative to the torso. The glenohumoral joint uses the Y-X-Y rotation sequence (elevation plane, elevation, rotation) recommended by the ISB (https://pubmed.ncbi.nlm.nih.gov/15844264/). Recommended for upper extremity tasks (e.g., pitching).
+                          </v-tooltip>
+                        </v-card-title>
+                        <v-card-text class="d-flex flex-column align-center checkbox-wrapper">
+                          <v-select
+                              v-model="openSimModel"
+                              label="Select musculoskeletal model"
+                              :items="openSimModels"
+                              item-text="text"
+                              item-value="value"
+                            />
+                        </v-card-text>
 
-                      <v-card-title class="justify-center data-title">
-                        <span class="mr-2">Marker augmenter model</span>
-                        <v-tooltip bottom="" max-width="500px">
-                          <template v-slot:activator="{ on }">
-                            <v-icon v-on="on"> mdi-help-circle-outline </v-icon>
-                          </template>
-                          OpenCap uses an LSTM model, also called marker augmenter model, to predict the 3D position of 43 anatomical markers from the 3D position of 20 video keypoints (https://www.biorxiv.org/content/10.1101/2022.07.07.499061v1). 
-                          The anatomical markers are used as input to OpenSim to compute joint angles using inverse kinematics.
-                          <br><br>
-                          The latest model (v0.3, default) is more accurate and more robust to different activities than v0.2. We recommend using it for new studies. 
-                          It was trained on 1475 hours of motion capture data and resulted in an RMSE of 4.4 +/- 0.3 deg (OpenPose) and 4.1 +/- 0.3 deg (HRnet) for joint angles across 18 degrees of freedom.
-                          <br><br>                  
-                          The original model (v0.2) underwent training using 708 hours of motion capture data, yielding an RMSE of 4.8 +/- 0.2 deg (OpenPose and HRNet) for joint angles across 18 degrees of freedom. 
-                          <br><br>
-                          The performance evaluation was conducted in comparison to marker-based motion capture using data from 10 subjects performing 4 different types of activities (walking, squatting, sit-to-stand, and drop jumps). 
-                          The dataset used for training the latest model (v0.3) contains data from more subjects and from a more diverse set of tasks; model v0.3 is therefore expected to be more accurate for a wider variety of tasks and to yield more accurate results.
-                          We recommend using v0.3 for new studies but warn users that we might still adjust the model in the future. 
-                          If you would like to use the model that was default prior to 07-30-2023, select v0.2.
-                        </v-tooltip>
-                      </v-card-title>
-                      <v-card-text class="d-flex flex-column align-center checkbox-wrapper">
-                        <v-select
-                            v-model="augmenter_model"
-                            label="Select marker augmenter model"
-                            :items="augmenter_models"
-                            item-text="text"
-                            item-value="value"
-                          />
-                      </v-card-text>
+                        <v-card-title class="justify-center data-title">
+                          <span class="mr-2">Marker augmenter model</span>
+                          <v-tooltip bottom="" max-width="500px">
+                            <template v-slot:activator="{ on }">
+                              <v-icon v-on="on"> mdi-help-circle-outline </v-icon>
+                            </template>
+                            OpenCap uses an LSTM model, also called marker augmenter model, to predict the 3D position of 43 anatomical markers from the 3D position of 20 video keypoints (https://www.biorxiv.org/content/10.1101/2022.07.07.499061v1).
+                            The anatomical markers are used as input to OpenSim to compute joint angles using inverse kinematics.
+                            <br><br>
+                            The latest model (v0.3, default) is more accurate and more robust to different activities than v0.2. We recommend using it for new studies.
+                            It was trained on 1475 hours of motion capture data and resulted in an RMSE of 4.4 +/- 0.3 deg (OpenPose) and 4.1 +/- 0.3 deg (HRnet) for joint angles across 18 degrees of freedom.
+                            <br><br>
+                            The original model (v0.2) underwent training using 708 hours of motion capture data, yielding an RMSE of 4.8 +/- 0.2 deg (OpenPose and HRNet) for joint angles across 18 degrees of freedom.
+                            <br><br>
+                            The performance evaluation was conducted in comparison to marker-based motion capture using data from 10 subjects performing 4 different types of activities (walking, squatting, sit-to-stand, and drop jumps).
+                            The dataset used for training the latest model (v0.3) contains data from more subjects and from a more diverse set of tasks; model v0.3 is therefore expected to be more accurate for a wider variety of tasks and to yield more accurate results.
+                            We recommend using v0.3 for new studies but warn users that we might still adjust the model in the future.
+                            If you would like to use the model that was default prior to 07-30-2023, select v0.2.
+                          </v-tooltip>
+                        </v-card-title>
+                        <v-card-text class="d-flex flex-column align-center checkbox-wrapper">
+                          <v-select
+                              v-model="augmenter_model"
+                              label="Select marker augmenter model"
+                              :items="augmenter_models"
+                              item-text="text"
+                              item-value="value"
+                            />
+                        </v-card-text>
 
-                      <v-card-title class="justify-center data-title">
-                        <span class="mr-2">Filter frequency</span>
-                        <v-tooltip bottom="" max-width="500px">
-                          <template v-slot:activator="{ on }">
-                            <v-icon v-on="on"> mdi-help-circle-outline </v-icon>
-                          </template>
-                          OpenCap uses a low-pass Butterworth filter to smooth the 2D video keypoints. The filter frequency is the cutoff frequency of the filter.
-                          <br><br>                  
-                          By default, OpenCap uses a filter frequency of half the framerate (if the framerate is 60fps, the filter frequency is 30Hz), except for gait activities, for which the filter frequency is 12Hz.
-                          <br><br>
-                          You can here enter a different filter frequency. WARNING: this filter frequency will be applied to ALL motion trials of your session. As per the Nyquist Theorem, the filter frequency should be less than half the framerate.
-                          If you enter a filter frequency higher than half the framerate, we will use half the framerate as the filter frequency instead.
-                          <br><br>
-                          We recommend consulting the literature to find a suitable filter frequency for your specific tasks. If you are unsure, we recommend using the default filter frequency.
-                        </v-tooltip>
-                      </v-card-title>
-                      <v-card-text class="d-flex flex-column align-center checkbox-wrapper">
-                        <v-combobox
-                        :key="componentKey"
-                        v-model="tempFilterFrequency"
-                        label="Enter frequency (Hz) or choose default"
-                        :items="filter_frequencies"
-                        :allow-custom="true"
-                        :return-object="false"
-                        @change="validateAndSetFrequency"
-                        item-text="text"
-                        item-value="value"
-                        ></v-combobox>
-                      </v-card-text>
+                        <v-card-title class="justify-center data-title">
+                          <span class="mr-2">Filter frequency</span>
+                          <v-tooltip bottom="" max-width="500px">
+                            <template v-slot:activator="{ on }">
+                              <v-icon v-on="on"> mdi-help-circle-outline </v-icon>
+                            </template>
+                            OpenCap uses a low-pass Butterworth filter to smooth the 2D video keypoints. The filter frequency is the cutoff frequency of the filter.
+                            <br><br>
+                            By default, OpenCap uses a filter frequency of half the framerate (if the framerate is 60fps, the filter frequency is 30Hz), except for gait activities, for which the filter frequency is 12Hz.
+                            <br><br>
+                            You can here enter a different filter frequency. WARNING: this filter frequency will be applied to ALL motion trials of your session. As per the Nyquist Theorem, the filter frequency should be less than half the framerate.
+                            If you enter a filter frequency higher than half the framerate, we will use half the framerate as the filter frequency instead.
+                            <br><br>
+                            We recommend consulting the literature to find a suitable filter frequency for your specific tasks. If you are unsure, we recommend using the default filter frequency.
+                          </v-tooltip>
+                        </v-card-title>
+                        <v-card-text class="d-flex flex-column align-center checkbox-wrapper">
+                          <v-combobox
+                          :key="componentKey"
+                          v-model="tempFilterFrequency"
+                          label="Enter frequency (Hz) or choose default"
+                          :items="filter_frequencies"
+                          :allow-custom="true"
+                          :return-object="false"
+                          @change="validateAndSetFrequency"
+                          item-text="text"
+                          item-value="value"
+                          ></v-combobox>
+                        </v-card-text>
+                      </div>
                       <v-card-actions class="advanced-settings-footer justify-end">
                         <v-btn
                           text
@@ -325,9 +327,9 @@
                           color="primary-dark"
                           :loading="savingAdvancedSettings"
                           :disabled="savingAdvancedSettings || !hasUnsavedAdvancedSettings"
-                          @click="saveAdvancedSettings"
+                          @click="saveAdvancedSettingsAndClose"
                         >
-                          Save
+                          Save and exit
                         </v-btn>
                       </v-card-actions>
                     </v-card>
@@ -1481,7 +1483,8 @@ export default {
     max-width: 100%;
     box-sizing: border-box;
     overflow-x: hidden !important;
-    overflow-y: auto !important;
+    overflow-y: hidden !important;
+    height: min(90vh, 820px);
     max-height: 90vh;
     display: flex;
     flex-direction: column;
@@ -1541,6 +1544,15 @@ export default {
     ::v-deep .v-tooltip span {
       background-color: transparent !important;
     }
+  }
+
+  .advanced-settings-body {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-x: hidden;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    background-color: #252525 !important;
   }
   
   .v-card__title.data-title {
@@ -1659,10 +1671,7 @@ export default {
     z-index: 30;
     margin-top: 0;
     margin-bottom: 0;
-    position: sticky;
-    top: 0;
-    left: 0;
-    right: 0;
+    position: relative;
     background-color: #252525 !important;
     border-bottom: 1px solid rgba(255,255,255,0.08);
     
@@ -1709,10 +1718,7 @@ export default {
   }
 
   .v-card__actions.advanced-settings-footer {
-    position: sticky;
-    bottom: 0;
-    left: 0;
-    right: 0;
+    position: relative;
     z-index: 20;
     padding: 16px;
     gap: 12px;

--- a/src/components/pages/Neutral.vue
+++ b/src/components/pages/Neutral.vue
@@ -1477,6 +1477,9 @@ export default {
 /* Advanced Settings Dialog Responsive Styles */
 .advanced-settings-dialog {
   z-index: 200 !important;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
   
   .v-card.advanced-settings-card {
     width: 100%;
@@ -1719,6 +1722,7 @@ export default {
 
   .v-card__actions.advanced-settings-footer {
     position: relative;
+    flex-shrink: 0;
     z-index: 20;
     padding: 16px;
     gap: 12px;
@@ -1736,6 +1740,26 @@ export default {
     .v-btn:not(.primary-dark) {
       color: #ffffff !important;
       background: rgba(255,255,255,0.08) !important;
+    }
+  }
+
+  @media (max-width: 599px) {
+    margin: 12px !important;
+    width: calc(100vw - 24px) !important;
+    max-width: calc(100vw - 24px) !important;
+    height: calc(100vh - 24px);
+    height: calc(100dvh - 24px);
+    max-height: calc(100vh - 24px);
+    max-height: calc(100dvh - 24px);
+
+    .v-card.advanced-settings-card {
+      height: 100%;
+      max-height: 100%;
+      min-height: 0;
+    }
+
+    .v-card__actions.advanced-settings-footer {
+      padding: 12px;
     }
   }
   


### PR DESCRIPTION
Changed save to save and exit and made it so only the body of advanced settings can scroll so the header and footer are always visible even on phone