### PR TITLE
Fix recursive trial polling duplicates

### DIFF
--- a/src/components/pages/Calibration.vue
+++ b/src/components/pages/Calibration.vue
@@ -141,6 +141,7 @@ export default {
       n_videos_uploaded: 0,
       isAuditoryFeedbackEnabled: false,
       timeoutID: null,
+      pollID: 0,
     }
   },
   created() {
@@ -163,6 +164,10 @@ export default {
   mounted () {
       this.loadSession(this.$route.params.id)
   },
+  beforeDestroy() {
+    this.pollID++
+    this.cancelPoll()
+  },
   methods: {
     ...mapMutations('data', ['setCalibration', 'setTrialId']),
     ...mapActions('data', ['loadSession']),
@@ -171,6 +176,8 @@ export default {
         const query = this.$route.query.isMono === 'true' ? { isMono: 'true' } : {}
         this.$router.push({ path: `/${this.session.id}/neutral`, query })
       } else {
+        this.cancelPoll()
+        const pollID = ++this.pollID
         this.lastPolledStatus = "";
         // Record press
         this.busy = true
@@ -196,22 +203,24 @@ export default {
             }
           })
           this.setTrialId(res.data.id)
-          this.pollStatus()
+          this.pollStatus(pollID)
         } catch (error) {
           apiError(error)
           this.busy = false
         }
       }
     },
-    async pollStatus() {
+    async pollStatus(pollID = this.pollID) {
       try {
         const res = await axiosGetWithRetry(`/sessions/${this.session.id}/calibration_img/`)
+        if (pollID !== this.pollID) return
         switch (res.data.status) {
           case "done": {
-            clearTimeout(this.timeoutID);
+            this.cancelPoll()
             clearToastMessages()
 
             const resCalibratedCameras = await axiosGetWithRetry(`/sessions/${this.$route.params.id}/get_n_calibrated_cameras/`, {})
+            if (pollID !== this.pollID) return
 
             this.n_calibrated_cameras = resCalibratedCameras.data.data
 
@@ -230,9 +239,10 @@ export default {
             break;
           }
           case "error": {
-            clearTimeout(this.timeoutID);
+            this.cancelPoll()
             clearToastMessages()
             const res_trial = await axiosGetWithRetry(`/trials/${this.trialId}/`)
+            if (pollID !== this.pollID) return
             apiErrorRes(res_trial, 'Finished with error')
             this.busy = false;
 
@@ -245,11 +255,12 @@ export default {
               res.data.status !== this.lastPolledStatus
             ) {
               const resCalibratedCameras = await axiosGetWithRetry(`/sessions/${this.$route.params.id}/get_n_calibrated_cameras/`, {})
+              if (pollID !== this.pollID) return
 
               this.n_calibrated_cameras = resCalibratedCameras.data.data
 
               if (this.n_calibrated_cameras < 2) {
-                clearTimeout(this.timeoutID);
+                this.cancelPoll()
                 clearToastMessages()
                 apiError(this.n_calibrated_cameras + " device(s) connected to the session and 2+ devices are required, please re-pair the devices using qr code at top of page.", 10000);
                 this.busy = false
@@ -260,7 +271,7 @@ export default {
             }
             this.lastPolledStatus = res.data.status;
             if (this.busy) {
-              this.timeoutID = window.setTimeout(this.pollStatus, 1000);
+              this.timeoutID = window.setTimeout(() => this.pollStatus(pollID), 1000);
             }
             break;
           }
@@ -268,14 +279,21 @@ export default {
 
         // Get n_cameras_connected.
         const res_status = await axiosGetWithRetry(`/sessions/${this.session.id}/status/`, {})
+        if (pollID !== this.pollID) return
 
         this.n_videos_uploaded = res_status.data.n_videos_uploaded
         this.n_cameras_connected = res_status.data.n_cameras_connected
       } catch (error) {
+        if (pollID !== this.pollID) return
+        this.cancelPoll()
         clearToastMessages()
         apiError(error);
         this.busy = false;
       }
+    },
+    cancelPoll() {
+      if (this.timeoutID) window.clearTimeout(this.timeoutID)
+      this.timeoutID = null
     },
   }
 }

--- a/src/components/pages/Neutral.vue
+++ b/src/components/pages/Neutral.vue
@@ -521,6 +521,8 @@ export default {
       tempFilterFrequency: 'default',
       componentKey: 0,
       isAuditoryFeedbackEnabled: false,
+      timeoutID: null,
+      pollID: 0,
     };
   },
   created() {
@@ -649,6 +651,10 @@ export default {
       this.n_calibrated_cameras = res.data.data
     }
     this.loadSubjectsList(false)
+  },
+  beforeDestroy() {
+    this.pollID++
+    this.cancelPoll()
   },
   watch: {
     subject (newVal, oldVal) {
@@ -959,6 +965,8 @@ export default {
           }
 
           if (await this.$refs.observer.validate()) {
+            this.cancelPoll()
+            const pollID = ++this.pollID
             apiInfo("Recording...")
             this.lastPolledStatus = "";
             this.busy = true;
@@ -1008,7 +1016,7 @@ export default {
                 }
               );
               this.setTrialId(res.data.id);
-              this.pollStatus();
+              this.pollStatus(pollID);
             } catch (error) {
               apiError(error);
             }
@@ -1016,13 +1024,15 @@ export default {
         }
       }
     },
-    async pollStatus() {
+    async pollStatus(pollID = this.pollID) {
       try {
         const res = await axios.get(
           `/sessions/${this.session.id}/neutral_img/`
         );
+        if (pollID !== this.pollID) return
         switch (res.data.status) {
           case "done": {
+            this.cancelPoll()
             clearToastMessages()
             this.$router.push({
               name: "Session",
@@ -1034,17 +1044,21 @@ export default {
             break;
           }
           case "error": {
+            this.cancelPoll()
             const resTrial = await axios.get(`/trials/${this.trialId}/`);
+            if (pollID !== this.pollID) return
             clearToastMessages();
             apiErrorRes(resTrial, "Error in processing neutral pose");
             this.busy = false;
 
             const resStatus = await axios.get(`/sessions/${this.$route.params.id}/status/`, {})
+            if (pollID !== this.pollID) return
 
             this.n_cameras_connected = resStatus.data.n_cameras_connected
             this.n_videos_uploaded = resStatus.data.n_videos_uploaded
 
             const resCalibratedCameras = await axios.get(`/sessions/${this.$route.params.id}/get_n_calibrated_cameras/`, {})
+            if (pollID !== this.pollID) return
 
             this.n_calibrated_cameras = resCalibratedCameras.data.data
 
@@ -1057,6 +1071,7 @@ export default {
           }
           default: {
             const resStatus = await axios.get(`/sessions/${this.$route.params.id}/status/`, {})
+            if (pollID !== this.pollID) return
 
             this.n_videos_uploaded = resStatus.data.n_videos_uploaded
 
@@ -1071,13 +1086,20 @@ export default {
                 playNeutralFinishedSound()
             }
             this.lastPolledStatus = res.data.status;
-            window.setTimeout(this.pollStatus, 1000);
+            if (this.busy) this.timeoutID = window.setTimeout(() => this.pollStatus(pollID), 1000);
             break;
           }
         }
       } catch (error) {
+        if (pollID !== this.pollID) return
+        this.cancelPoll()
         apiError(error);
+        this.busy = false;
       }
+    },
+    cancelPoll() {
+      if (this.timeoutID) window.clearTimeout(this.timeoutID)
+      this.timeoutID = null
     },
     openAdvancedSettings() {
       this.advancedSettingsDialog = true;

--- a/src/components/pages/Session.vue
+++ b/src/components/pages/Session.vue
@@ -1022,6 +1022,7 @@
               recordingStatusPoll: null,
 
               trialsPoll: null,
+              trialsPollActive: false,
               showSessionMenuButtons: false,
               leftMenuOpen: false,
   
@@ -1837,10 +1838,19 @@
           window.clearTimeout(this.statusPoll)
         }
       },
-      async startTrialsPoll() {
-        this.trialsPoll = window.setTimeout(async () => {
+      startTrialsPoll() {
+        if (this.trialsPollActive) return
+
+        this.trialsPollActive = true
+        const poll = async () => {
+          this.trialsPoll = null
+          const sessionId = this.session?.id
+          if (!this.trialsPollActive || !sessionId) return
+
           try {
-            const res = await axios.get(`/sessions/${this.session.id}/status/?ret_session=true`)
+            const res = await axios.get(`/sessions/${sessionId}/status/?ret_session=true`)
+            if (!this.trialsPollActive || this.session?.id !== sessionId) return
+
             const updatedTrials = res.data.session.trials || []
 
             // Add new trials and update existing ones
@@ -1856,10 +1866,15 @@
             // Ignore poll errors (e.g. session no longer exists)
           }
 
-          this.startTrialsPoll()
-        }, 5000)
+          if (this.trialsPollActive && this.session?.id === sessionId) {
+            this.trialsPoll = window.setTimeout(poll, 5000)
+          }
+        }
+
+        this.trialsPoll = window.setTimeout(poll, 5000)
       },
       cancelTrialsPoll() {
+        this.trialsPollActive = false
         if (this.trialsPoll) {
           window.clearTimeout(this.trialsPoll)
           this.trialsPoll = null

--- a/src/components/pages/Session.vue
+++ b/src/components/pages/Session.vue
@@ -1807,6 +1807,7 @@
         this.$router.push({name: 'Neutral', params: {id: this.session.id}, query})
       },
       startPoll() {
+        this.cancelPoll()
         this.statusPoll = window.setTimeout(async () => {
           const res = await axios.get(`/sessions/${this.session.id}/status/`)
           this.n_cameras_connected = res.data.n_cameras_connected
@@ -1836,6 +1837,7 @@
       cancelPoll() {
         if (this.statusPoll) {
           window.clearTimeout(this.statusPoll)
+          this.statusPoll = null
         }
       },
       startTrialsPoll() {

--- a/src/store/data.js
+++ b/src/store/data.js
@@ -272,7 +272,16 @@ export default {
       state.trialName = ''       
     },
     addTrial (state, trial) {
-      state.session.trials.push(trial)
+      if (!state.session.trials) {
+        Vue.set(state.session, 'trials', [])
+      }
+
+      const index = trial?.id ? state.session.trials.findIndex(t => t.id === trial.id) : -1
+      if (index >= 0) {
+        Vue.set(state.session.trials, index, trial)
+      } else {
+        state.session.trials.push(trial)
+      }
     },
     updateTrial (state, trial) {
       const index = state.session.trials.findIndex(t => t.id === trial.id)


### PR DESCRIPTION

Fix for #497 

Fixes duplicate trial entries caused by overlapping Session page polling.

Prevents multiple trial polling loops from running at once with flag
Stops stale/cancelled polls from updating session state
Makes addTrial() update existing sessions instead of adding them again
