### PR TITLE
Removed dep package vue-country-dropdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "chartjs-plugin-zoom": "^2.0.1",
     "chroma-js": "^2.4.2",
     "core-js": "^3.6.5",
+    "flag-icons": "^7.5.0",
     "hammerjs": "^2.0.8",
     "jspdf": "^2.5.1",
     "moment": "^2.29.1",
@@ -86,7 +87,11 @@
       "!**/node_modules/**",
       "!**/tests/**"
     ],
-    "coverageReporters": ["text", "lcov", "html"],
+    "coverageReporters": [
+      "text",
+      "lcov",
+      "html"
+    ],
     "verbose": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "vee-validate": "^3.4.14",
     "vue": "^2.6.11",
     "vue-chartjs": "^4.1.1",
-    "vue-country-dropdown": "^2.0.8",
     "vue-gl": "^0.22.1",
     "vue-router": "^3.5.2",
     "vue-social-sharing": "^3.0.9",

--- a/src/components/pages/ProfilePage.vue
+++ b/src/components/pages/ProfilePage.vue
@@ -213,7 +213,7 @@
 
                   <div class="row">
                     <div class="col-md-6">
-                      <vue-country-dropdown
+                      <country-dropdown
                         ref="vcd"
                         @onSelect="onSelectCountry"
                         :preferredCountries="['US']"
@@ -222,7 +222,7 @@
                         :enabledFlags="true"
                         :enabledCountryCode="false"
                         :showNameInput="true">
-                      </vue-country-dropdown>
+                      </country-dropdown>
                     </div>
                   </div>
 
@@ -449,7 +449,7 @@
 </template>
 
 <script>
-import VueCountryDropdown from 'vue-country-dropdown'
+import CountryDropdown from '@/components/ui/CountryDropdown.vue'
 import allCountries from "@/util/allCountries.js"
 import { mapState, mapActions } from 'vuex'
 import axios from 'axios'
@@ -458,7 +458,7 @@ import { copyProfileUrlToClipboard } from "@/util/CopyUrlToClipboard.js";
 
 export default {
   components: {
-    VueCountryDropdown
+    CountryDropdown
   },
   computed: {
     ...mapState({
@@ -1065,43 +1065,5 @@ export default {
 <style>
 .v-main:has(.profile-page-wrapper) {
   overflow: visible;
-}
-
-/* vue-country-dropdown dark theme for Edit Profile */
-.profile-page-wrapper .vue-country-select .country-name {
-  color: hsla(0, 0%, 100%, 0.7) !important;
-}
-.profile-page-wrapper div.dropdown.open {
-  background-color: black !important;
-}
-.profile-page-wrapper .vue-country-select .country-name:hover {
-  color: hsla(0, 0%, 100%, 0.7) !important;
-}
-.profile-page-wrapper .dropdown:hover {
-  background-color: black !important;
-}
-.profile-page-wrapper li.dropdown-item {
-  background-color: black !important;
-}
-.profile-page-wrapper li.dropdown-item:hover {
-  background-color: rgb(46, 46, 46) !important;
-}
-.profile-page-wrapper li.dropdown-item > strong {
-  font-weight: normal !important;
-  color: hsla(0, 0%, 100%, 0.7);
-}
-.profile-page-wrapper .vue-country-select {
-  width: 100%;
-  border-color: hsla(0, 0%, 100%, 0.7) !important;
-}
-.profile-page-wrapper .vue-country-select:hover {
-  border-color: white !important;
-}
-.profile-page-wrapper .vue-country-select:focus,
-.profile-page-wrapper .vue-country-select:active {
-  border-color: white !important;
-}
-.profile-page-wrapper li.dropdown-item > span {
-  display: none;
 }
 </style>

--- a/src/components/pages/ProfilePage.vue
+++ b/src/components/pages/ProfilePage.vue
@@ -212,7 +212,7 @@
                   </div>
 
                   <div class="row">
-                    <div class="col-md-6">
+                    <div class="col-12">
                       <country-dropdown
                         ref="vcd"
                         @onSelect="onSelectCountry"

--- a/src/components/pages/Register.vue
+++ b/src/components/pages/Register.vue
@@ -90,7 +90,7 @@
 
                 </div>
                 <div class="col-md-6">
-                 <vue-country-dropdown
+                 <country-dropdown
                     ref="vcd"
                     @onSelect="onSelectCountry"
                     :preferredCountries="['US']"
@@ -99,7 +99,7 @@
                     :enabledFlags="true"
                     :enabledCountryCode="false"
                     :showNameInput="true">
-                  </vue-country-dropdown>
+                  </country-dropdown>
                 </div>
               </div>
 
@@ -335,12 +335,12 @@
 <script>
 import { mapActions, mapState } from "vuex";
 import { apiSuccess, apiError } from "@/util/ErrorMessage.js";
-import VueCountryDropdown from 'vue-country-dropdown'
+import CountryDropdown from '@/components/ui/CountryDropdown.vue'
 
 export default {
   name: "Register",
   components: {
-    VueCountryDropdown
+    CountryDropdown
   },
   data() {
     return {
@@ -487,7 +487,7 @@ export default {
   }
 
   .row .col-md-6 + .col-md-6 .v-text-field,
-  .row .col-md-6 + .col-md-6 .vue-country-select,
+  .row .col-md-6 + .col-md-6 .country-dropdown,
   .row .col-12 .v-text-field {
     margin-top: 0;
   }
@@ -543,45 +543,6 @@ export default {
   }
 }
 
-// Vue country dropdown - needs :deep for child components
-:deep(.vue-country-select) .country-name {
-  color: hsla(0,0%,100%,.7) !important;
-}
-:deep(div.dropdown.open) {
-  background-color: black !important;
-}
-:deep(.vue-country-select .country-name:hover) {
-  color: hsla(0,0%,100%,.7) !important;
-}
-:deep(.dropdown:hover) {
-  background-color: black !important;
-}
-:deep(li.dropdown-item) {
-  background-color: black !important;
-}
-:deep(li.dropdown-item:hover) {
-  background-color: rgb(46, 46, 46) !important;
-}
-:deep(li.dropdown-item > strong) {
-  font-weight: normal !important;
-  color: hsla(0,0%,100%,.7);
-}
-:deep(.vue-country-select) {
-  width: 100%;
-  border-color: hsla(0,0%,100%,.7) !important;
-}
-:deep(.vue-country-select:hover) {
-  border-color: white !important;
-}
-:deep(.vue-country-select:focus) {
-  border-color: white !important;
-}
-:deep(.vue-country-select:active) {
-  border-color: white !important;
-}
-:deep(li.dropdown-item > span) {
-  display: none;
-}
 .show-pass-icon {
   width: auto;
 }

--- a/src/components/ui/CountryDropdown.vue
+++ b/src/components/ui/CountryDropdown.vue
@@ -14,12 +14,14 @@
     :menu-props="{ dark: true, offsetY: true }"
     @change="onChange">
     <template #selection="{ item }">
-      <span v-if="enabledFlags" class="country-flag">{{ item.flag }}</span>
-      <span class="country-name">{{ item.name }}</span>
-      <span v-if="enabledCountryCode && item.dialCode" class="country-dial">+{{ item.dialCode }}</span>
+      <span class="country-selection">
+        <span v-if="enabledFlags" class="country-flag fi" :class="flagClass(item.iso2)"></span>
+        <span class="country-name">{{ item.name }}</span>
+        <span v-if="enabledCountryCode && item.dialCode" class="country-dial">+{{ item.dialCode }}</span>
+      </span>
     </template>
     <template #item="{ item }">
-      <span v-if="enabledFlags" class="country-flag">{{ item.flag }}</span>
+      <span v-if="enabledFlags" class="country-flag fi" :class="flagClass(item.iso2)"></span>
       <span class="country-name">{{ item.name }}</span>
       <span v-if="enabledCountryCode && item.dialCode" class="country-dial">+{{ item.dialCode }}</span>
     </template>
@@ -28,16 +30,9 @@
 
 <script>
 import allCountries from "@/util/allCountries.js";
-
-// Convert an ISO 3166-1 alpha-2 code into a flag emoji using regional
-// indicator symbols. Returns an empty string for invalid/empty codes.
-function isoToFlag(iso2) {
-  if (!iso2 || iso2.length !== 2) return "";
-  const code = iso2.toUpperCase();
-  return String.fromCodePoint(
-    ...[...code].map((c) => 0x1f1e6 + (c.charCodeAt(0) - 65))
-  );
-}
+// Bundled SVG flags (rendered consistently on every OS, unlike emoji flags
+// which don't exist on Windows).
+import "flag-icons/css/flag-icons.min.css";
 
 export default {
   name: "CountryDropdown",
@@ -81,7 +76,6 @@ export default {
           name: c.name,
           iso2: c.iso2,
           dialCode: c.dialCode,
-          flag: isoToFlag(c.iso2),
         }));
     },
     items() {
@@ -117,6 +111,9 @@ export default {
       const match = this.countries.find((c) => c.iso2 === iso2);
       if (match) this.emitSelect(match);
     },
+    flagClass(iso2) {
+      return iso2 ? `fi-${iso2.toLowerCase()}` : "";
+    },
     emitSelect({ name, iso2, dialCode }) {
       this.$emit("onSelect", { name, iso2, dialCode });
     },
@@ -125,16 +122,42 @@ export default {
 </script>
 
 <style scoped>
+.country-selection {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: nowrap;
+  white-space: nowrap;
+  min-width: 0;
+  max-width: 100%;
+}
 .country-flag {
   margin-right: 8px;
-  font-size: 1.1rem;
-  line-height: 1;
+  flex-shrink: 0;
+  width: 1.33em;
+  height: 1em;
+  border-radius: 2px;
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.12);
 }
 .country-name {
   color: hsla(0, 0%, 100%, 0.85);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .country-dial {
   margin-left: 8px;
   color: hsla(0, 0%, 100%, 0.55);
+  flex-shrink: 0;
+}
+
+/* Clip the selected name at the field's edge instead of letting a long
+   country name stretch the input (and the whole card) wider. */
+.country-dropdown ::v-deep .v-select__selections {
+  flex-wrap: nowrap;
+  overflow: hidden;
+}
+.country-dropdown ::v-deep .v-select__selections input {
+  min-width: 0;
 }
 </style>

--- a/src/components/ui/CountryDropdown.vue
+++ b/src/components/ui/CountryDropdown.vue
@@ -1,0 +1,140 @@
+<template>
+  <v-autocomplete
+    class="country-dropdown"
+    :items="items"
+    :value="selectedIso2"
+    item-text="name"
+    item-value="iso2"
+    label="Country"
+    dark
+    outlined
+    dense
+    hide-details
+    auto-select-first
+    :menu-props="{ dark: true, offsetY: true }"
+    @change="onChange">
+    <template #selection="{ item }">
+      <span v-if="enabledFlags" class="country-flag">{{ item.flag }}</span>
+      <span class="country-name">{{ item.name }}</span>
+      <span v-if="enabledCountryCode && item.dialCode" class="country-dial">+{{ item.dialCode }}</span>
+    </template>
+    <template #item="{ item }">
+      <span v-if="enabledFlags" class="country-flag">{{ item.flag }}</span>
+      <span class="country-name">{{ item.name }}</span>
+      <span v-if="enabledCountryCode && item.dialCode" class="country-dial">+{{ item.dialCode }}</span>
+    </template>
+  </v-autocomplete>
+</template>
+
+<script>
+import allCountries from "@/util/allCountries.js";
+
+// Convert an ISO 3166-1 alpha-2 code into a flag emoji using regional
+// indicator symbols. Returns an empty string for invalid/empty codes.
+function isoToFlag(iso2) {
+  if (!iso2 || iso2.length !== 2) return "";
+  const code = iso2.toUpperCase();
+  return String.fromCodePoint(
+    ...[...code].map((c) => 0x1f1e6 + (c.charCodeAt(0) - 65))
+  );
+}
+
+export default {
+  name: "CountryDropdown",
+  props: {
+    preferredCountries: {
+      type: Array,
+      default: () => [],
+    },
+    defaultCountry: {
+      type: String,
+      default: "",
+    },
+    immediateCallSelectEvent: {
+      type: Boolean,
+      default: false,
+    },
+    enabledFlags: {
+      type: Boolean,
+      default: true,
+    },
+    enabledCountryCode: {
+      type: Boolean,
+      default: false,
+    },
+    // Kept for API parity with the previous vue-country-dropdown component.
+    showNameInput: {
+      type: Boolean,
+      default: true,
+    },
+  },
+  data() {
+    return {
+      selectedIso2: "",
+    };
+  },
+  computed: {
+    countries() {
+      return allCountries
+        .filter((c) => c.iso2)
+        .map((c) => ({
+          name: c.name,
+          iso2: c.iso2,
+          dialCode: c.dialCode,
+          flag: isoToFlag(c.iso2),
+        }));
+    },
+    items() {
+      const preferred = this.preferredCountries.map((c) => c.toUpperCase());
+      if (!preferred.length) return this.countries;
+      const top = [];
+      preferred.forEach((iso2) => {
+        const match = this.countries.find((c) => c.iso2 === iso2);
+        if (match) top.push(match);
+      });
+      const rest = this.countries.filter((c) => !preferred.includes(c.iso2));
+      return [...top, ...rest];
+    },
+  },
+  watch: {
+    defaultCountry(iso2) {
+      this.applyDefault(iso2, false);
+    },
+  },
+  mounted() {
+    this.applyDefault(this.defaultCountry, this.immediateCallSelectEvent);
+  },
+  methods: {
+    applyDefault(iso2, emitEvent) {
+      const code = (iso2 || "").toUpperCase();
+      const match = this.countries.find((c) => c.iso2 === code);
+      if (!match) return;
+      this.selectedIso2 = match.iso2;
+      if (emitEvent) this.emitSelect(match);
+    },
+    onChange(iso2) {
+      this.selectedIso2 = iso2;
+      const match = this.countries.find((c) => c.iso2 === iso2);
+      if (match) this.emitSelect(match);
+    },
+    emitSelect({ name, iso2, dialCode }) {
+      this.$emit("onSelect", { name, iso2, dialCode });
+    },
+  },
+};
+</script>
+
+<style scoped>
+.country-flag {
+  margin-right: 8px;
+  font-size: 1.1rem;
+  line-height: 1;
+}
+.country-name {
+  color: hsla(0, 0%, 100%, 0.85);
+}
+.country-dial {
+  margin-left: 8px;
+  color: hsla(0, 0%, 100%, 0.55);
+}
+</style>


### PR DESCRIPTION

What I did
Addressed issue reported here https://github.com/opencap-org/opencap-viewer/issues/530
Eliminated the dependency

Removed vue-country-dropdown from package.json.
Removed both entries (the root dependency reference and the node_modules/... entry) from package-lock.json, so a fresh install won't try to fetch it.
Deleted the stale node_modules/vue-country-dropdown directory that was still sitting on disk.
Built a drop-in replacement at src/components/ui/CountryDropdown.vue

It reuses the country data already vendored in src/util/allCountries.js (no new packages, no network/CDN calls).
It keeps the exact same API the old component exposed, so the call sites barely changed: props preferredCountries, defaultCountry, immediateCallSelectEvent, enabledFlags, enabledCountryCode, showNameInput, and the @onSelect event emitting { name, iso2, dialCode }.
It renders as a searchable Vuetify v-autocomplete styled for the existing dark theme, with flag emoji derived from the ISO code (no flag-sprite asset needed).
Updated both call sites (Register.vue and ProfilePage.vue)

Swapped the import to @/components/ui/CountryDropdown.vue and the tag to <country-dropdown>.
Removed the old library-specific .vue-country-select / .dropdown-item global and :deep style overrides.